### PR TITLE
Avoid double-encoding urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "notebook"
   ],
   "files": [
-    "lib/index.js",
-    "lib/index.d.ts"
+    "lib/*.js",
+    "lib/*.d.ts"
   ],
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,8 @@ class ConfigSection implements IConfigSection {
    * Create a config section.
    */
   constructor(sectionName: string, baseUrl: string) {
-    this._url = utils.urlPathJoin(baseUrl, SERVICE_CONFIG_URL, sectionName);
+    this._url = utils.urlPathJoin(baseUrl, SERVICE_CONFIG_URL, 
+                                  utils.urlJoinEncode(sectionName));
   }
 
   /**

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -80,7 +80,7 @@ class Contents implements IContents {
    * Create a new contents object.
    */
   constructor(baseUrl: string) {
-    this._apiUrl = utils.urlJoinEncode(baseUrl, SERVICE_CONTENTS_URL);
+    this._apiUrl = utils.urlPathJoin(baseUrl, SERVICE_CONTENTS_URL);
   }
 
   /**
@@ -305,9 +305,10 @@ class Contents implements IContents {
    * Get an REST url for this file given a path.
    */
   private _getUrl(...args: string[]): string {
-    var url_parts = [this._apiUrl].concat(
+    var url_parts = [].concat(
                 Array.prototype.slice.apply(args));
-    return utils.urlJoinEncode.apply(null, url_parts);
+    return utils.urlPathJoin(this._apiUrl,
+                             utils.urlJoinEncode.apply(null, url_parts));
   }
 
   private _apiUrl = "unknown";

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -490,7 +490,8 @@ class Kernel implements IKernel {
         location.protocol.replace('http', 'ws') + "//" + location.host
       );
     }
-    var partialUrl = utils.urlPathJoin(wsUrl, KERNEL_SERVICE_URL, this._id);
+    var partialUrl = utils.urlPathJoin(wsUrl, KERNEL_SERVICE_URL, 
+                                       utils.urlJoinEncode(this._id));
     console.log('Starting WebSocket:', partialUrl);
 
     var url = (
@@ -754,7 +755,8 @@ var runningKernels = new Map<string, Kernel>();
  */
 function restartKernel(kernel: IKernel, baseUrl: string): Promise<void> {
   var url = utils.urlPathJoin(
-    baseUrl, KERNEL_SERVICE_URL, kernel.id, 'restart'
+    baseUrl, KERNEL_SERVICE_URL, 
+    utils.urlJoinEncode(kernel.id, 'restart')
   );
   return utils.ajaxRequest(url, {
     method: "POST",
@@ -795,7 +797,8 @@ function interruptKernel(kernel: IKernel, baseUrl: string): Promise<void> {
     return Promise.reject(new Error('Kernel is dead'));
   }
   var url = utils.urlPathJoin(
-    baseUrl, KERNEL_SERVICE_URL, kernel.id, 'interrupt'
+    baseUrl, KERNEL_SERVICE_URL, 
+    utils.urlJoinEncode(kernel.id, 'interrupt')
   );
   return utils.ajaxRequest(url, {
     method: "POST",
@@ -821,7 +824,8 @@ function shutdownKernel(kernel: Kernel, baseUrl: string): Promise<void> {
   if (kernel.status === KernelStatus.Dead) {
     return Promise.reject(new Error('Kernel is dead'));
   }
-  var url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL, kernel.id);
+  var url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL, 
+                              utils.urlJoinEncode(kernel.id));
   return utils.ajaxRequest(url, {
     method: "DELETE",
     dataType: "json"


### PR DESCRIPTION
Inspired by https://github.com/jupyter/notebook/pull/472.

Also, we were not including all of the generated files in package.json.

ping @minrk 