### PR TITLE
Allow options to ajax request calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postinstall": "npm dedupe",
     "prepublish": "npm run build",
     "test": "mocha test/build/test*.js",
+    "test:debug": "pkill node; node-debug _mocha test/build/test*.js",
     "test:integration": "cd test && python run_test.py",
     "test:coverage": "istanbul cover _mocha -- test/build/test*.js"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { IAjaxOptions } from './utils';
+
 import * as utils from './utils';
 
 
@@ -37,9 +39,9 @@ interface IConfigSection {
  * data is loaded.
  */
 export
-function getConfigSection(sectionName: string, baseUrl: string): Promise<IConfigSection> {
+function getConfigSection(sectionName: string, baseUrl: string, ajaxOptions?: IAjaxOptions): Promise<IConfigSection> {
   var section = new ConfigSection(sectionName, baseUrl);
-  return section.load();
+  return section.load(ajaxOptions);
 }
 
 
@@ -68,11 +70,11 @@ class ConfigSection implements IConfigSection {
   /**
    * Load the initial data for this section.
    */
-  load(): Promise<IConfigSection> {
+  load(ajaxOptions?: IAjaxOptions): Promise<IConfigSection> {
     return utils.ajaxRequest(this._url, {
       method: "GET",
       dataType: "json",
-    }).then((success: utils.IAjaxSuccess) => {
+    }, ajaxOptions).then((success: utils.IAjaxSuccess) => {
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -86,7 +88,7 @@ class ConfigSection implements IConfigSection {
    * send the change to the server, and use the updated data from the server
    * when the reply comes.
    */
-  update(newdata: any): Promise<any> {
+  update(newdata: any, ajaxOptions?: IAjaxOptions): Promise<any> {
     this._data = utils.extend(this._data, newdata);
 
     return utils.ajaxRequest(this._url, {
@@ -94,7 +96,7 @@ class ConfigSection implements IConfigSection {
       data: JSON.stringify(newdata),
       dataType : "json",
       contentType: 'application/json',
-    }).then((success: utils.IAjaxSuccess) => {
+    }, ajaxOptions).then((success: utils.IAjaxSuccess) => {
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,17 +71,14 @@ class ConfigSection implements IConfigSection {
    * Load the initial data for this section.
    */
   load(ajaxOptions?: IAjaxOptions): Promise<IConfigSection> {
-    console.log('****LOAD');
     return utils.ajaxRequest(this._url, {
       method: "GET",
       dataType: "json",
     }, ajaxOptions).then((success: utils.IAjaxSuccess) => {
-      console.log('***LOAD RESPONSE');
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
       this._data = success.data;
-      console.log('***LOAD RESPONSE 2');
       return this;
     });
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,7 @@ interface IConfigSection {
    * send the change to the server, and use the updated data from the server
    * when the reply comes.
    */
-  update(newdata: any): Promise<any>;
+  update(newdata: any, ajaxOptions?: IAjaxOptions): Promise<any>;
 
 }
 
@@ -71,14 +71,17 @@ class ConfigSection implements IConfigSection {
    * Load the initial data for this section.
    */
   load(ajaxOptions?: IAjaxOptions): Promise<IConfigSection> {
+    console.log('****LOAD');
     return utils.ajaxRequest(this._url, {
       method: "GET",
       dataType: "json",
     }, ajaxOptions).then((success: utils.IAjaxSuccess) => {
+      console.log('***LOAD RESPONSE');
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
       this._data = success.data;
+      console.log('***LOAD RESPONSE 2');
       return this;
     });
   }

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { IAjaxOptions } from './utils';
+
 import * as utils from './utils';
+
 import * as validate from './validate';
 
 
@@ -56,17 +59,17 @@ interface ICheckpointModel {
  **/
 export 
 interface IContents {
-  get(path: string, type: string, options: IContentsOpts): Promise<IContentsModel>;
-  newUntitled(path: string, options: IContentsOpts): Promise<IContentsModel>;
-  delete(path: string): Promise<void>;
-  rename(path: string, newPath: string): Promise<IContentsModel>;
-  save(path: string, model: any): Promise<IContentsModel>;
-  listContents(path: string): Promise<IContentsModel>;
-  copy(path: string, toDir: string): Promise<IContentsModel>;
-  createCheckpoint(path: string): Promise<ICheckpointModel>;
-  restoreCheckpoint(path: string, checkpointID: string): Promise<void>;
-  deleteCheckpoint(path: string, checkpointID: string): Promise<void>
-  listCheckpoints(path: string): Promise<ICheckpointModel[]>;
+  get(path: string, type: string, options: IContentsOpts, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  newUntitled(path: string, options: IContentsOpts, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  delete(path: string, ajaxOptions?: IAjaxOptions): Promise<void>;
+  rename(path: string, newPath: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  save(path: string, model: any, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  listContents(path: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  copy(path: string, toDir: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel>;
+  createCheckpoint(path: string, ajaxOptions?: IAjaxOptions): Promise<ICheckpointModel>;
+  restoreCheckpoint(path: string, checkpointID: string, ajaxOptions?: IAjaxOptions): Promise<void>;
+  deleteCheckpoint(path: string, checkpointID: string, ajaxOptions?: IAjaxOptions): Promise<void>
+  listCheckpoints(path: string, ajaxOptions?: IAjaxOptions): Promise<ICheckpointModel[]>;
 }
 
 
@@ -87,7 +90,7 @@ class Contents implements IContents {
   /**
    * Get a file or directory.
    */
-  get(path: string, options: IContentsOpts): Promise<IContentsModel> {
+  get(path: string, options: IContentsOpts, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
     var settings = {
       method : "GET",
       dataType : "json",
@@ -98,7 +101,7 @@ class Contents implements IContents {
     if (options.format) { params.format = options.format; }
     if (options.content === false) { params.content = '0'; }
     url = url + utils.jsonToQueryString(params);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): IContentsModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): IContentsModel => {
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -110,7 +113,7 @@ class Contents implements IContents {
   /**
    * Create a new untitled file or directory in the specified directory path.
    */
-  newUntitled(path: string, options?: IContentsOpts): Promise<IContentsModel> {
+  newUntitled(path: string, options?: IContentsOpts, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
     var settings: utils.IAjaxSettings = {
         method : "POST",
         dataType : "json",
@@ -124,7 +127,7 @@ class Contents implements IContents {
       settings.contentType = 'application/json';
     }
     var url = this._getUrl(path);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): IContentsModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): IContentsModel => {
       if (success.xhr.status !== 201) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -136,13 +139,13 @@ class Contents implements IContents {
   /**
    * Delete a file.
    */
-  delete(path: string): Promise<void> {
+  delete(path: string, ajaxOptions?: IAjaxOptions): Promise<void> {
     var settings = {
       method : "DELETE",
       dataType : "json",
     };
     var url = this._getUrl(path);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): void => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): void => {
       if (success.xhr.status !== 204) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -161,7 +164,7 @@ class Contents implements IContents {
   /**
    * Rename a file.
    */
-  rename(path: string, newPath: string): Promise<IContentsModel> {
+  rename(path: string, newPath: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
     var data = {path: newPath};
     var settings = {
       method : "PATCH",
@@ -170,7 +173,7 @@ class Contents implements IContents {
       contentType: 'application/json',
     };
     var url = this._getUrl(path);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): IContentsModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): IContentsModel => {
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -182,7 +185,7 @@ class Contents implements IContents {
   /**
    * Save a file.
    */
-  save(path: string, model: IContentsOpts): Promise<IContentsModel> {
+  save(path: string, model: IContentsOpts, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
     var settings = {
       method : "PUT",
       dataType: "json",
@@ -190,7 +193,7 @@ class Contents implements IContents {
       contentType: 'application/json',
     };
     var url = this._getUrl(path);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): IContentsModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): IContentsModel => {
       // will return 200 for an existing file and 201 for a new file
       if (success.xhr.status !== 200 && success.xhr.status !== 201) {
         throw Error('Invalid Status: ' + success.xhr.status);
@@ -204,7 +207,7 @@ class Contents implements IContents {
    * Copy a file into a given directory via POST
    * The server will select the name of the copied file.
    */
-  copy(fromFile: string, toDir: string): Promise<IContentsModel> {
+  copy(fromFile: string, toDir: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
     var settings = {
       method: "POST",
       data: JSON.stringify({copy_from: fromFile}),
@@ -212,7 +215,7 @@ class Contents implements IContents {
       dataType : "json",
     };
     var url = this._getUrl(toDir);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): IContentsModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): IContentsModel => {
       if (success.xhr.status !== 201) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -224,13 +227,13 @@ class Contents implements IContents {
   /**
    * Create a checkpoint for a file.
    */
-  createCheckpoint(path: string): Promise<ICheckpointModel> {
+  createCheckpoint(path: string, ajaxOptions?: IAjaxOptions): Promise<ICheckpointModel> {
     var settings = {
       method : "POST",
       dataType : "json",
     };
     var url = this._getUrl(path, 'checkpoints');
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): ICheckpointModel => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): ICheckpointModel => {
       if (success.xhr.status !== 201) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -242,13 +245,13 @@ class Contents implements IContents {
   /** 
    * List available checkpoints for a file.
    */
-  listCheckpoints(path: string): Promise<ICheckpointModel[]> {
+  listCheckpoints(path: string, ajaxOptions?: IAjaxOptions): Promise<ICheckpointModel[]> {
     var settings = {
       method : "GET",
       dataType: "json",
     };
     var url = this._getUrl(path, 'checkpoints');
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): ICheckpointModel[] => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): ICheckpointModel[] => {
       if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -265,13 +268,13 @@ class Contents implements IContents {
   /**
    * Restore a file to a known checkpoint state.
    */
-  restoreCheckpoint(path: string, checkpointID: string): Promise<void> {
+  restoreCheckpoint(path: string, checkpointID: string, ajaxOptions?: IAjaxOptions): Promise<void> {
     var settings = {
       method : "POST",
       dataType: "json",
     };
     var url = this._getUrl(path, 'checkpoints', checkpointID);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): void => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): void => {
       if (success.xhr.status !== 204) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -282,13 +285,13 @@ class Contents implements IContents {
   /**
    * Delete a checkpoint for a file.
    */
-  deleteCheckpoint(path: string, checkpointID: string): Promise<void> {
+  deleteCheckpoint(path: string, checkpointID: string, ajaxOptions?: IAjaxOptions): Promise<void> {
     var settings = {
       method : "DELETE",
       dataType: "json",
     };
     var url = this._getUrl(path, 'checkpoints', checkpointID);
-    return utils.ajaxRequest(url, settings).then((success: utils.IAjaxSuccess): void => {
+    return utils.ajaxRequest(url, settings, ajaxOptions).then((success: utils.IAjaxSuccess): void => {
       if (success.xhr.status !== 204) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
@@ -298,8 +301,8 @@ class Contents implements IContents {
   /** 
    * List notebooks and directories at a given path.
    */
-  listContents(path: string): Promise<IContentsModel> {
-    return this.get(path, {type: 'directory'});
+  listContents(path: string, ajaxOptions?: IAjaxOptions): Promise<IContentsModel> {
+    return this.get(path, {type: 'directory'}, ajaxOptions);
   }
 
   /**

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -6,6 +6,8 @@ import { IDisposable } from 'phosphor-disposable';
 
 import { ISignal, Signal } from 'phosphor-signaling';
 
+import { IAjaxOptions } from './utils';
+
 
 export
 interface IKernelOptions {
@@ -319,14 +321,14 @@ interface IKernel {
   /**
    * Interrupt a kernel via API: POST /kernels/{kernel_id}/interrupt
    */
-  interrupt(): Promise<void>;
+  interrupt(ajaxOptions?: IAjaxOptions): Promise<void>;
 
   /**
    * Restart a kernel via API: POST /kernels/{kernel_id}/restart
    *
    * It is assumed that the API call does not mutate the kernel id or name.
    */
-  restart(): Promise<void>;
+  restart(ajaxOptions?: IAjaxOptions): Promise<void>;
 
   /**
    * Delete a kernel via API: DELETE /kernels/{kernel_id}
@@ -337,7 +339,7 @@ interface IKernel {
    * Any further calls to `sendMessage` for that Kernel will throw
    * an exception.
    */
-  shutdown(): Promise<void>;
+  shutdown(ajaxOptions?: IAjaxOptions): Promise<void>;
 
   /**
    * Send a "kernel_info_request" message.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './ikernel';
 export * from './isession';
 export * from './kernel';
 export * from './session';
+export { IAjaxOptions } from './utils';

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -6,6 +6,8 @@ import { ISignal, Signal } from 'phosphor-signaling';
 
 import { IKernel, IKernelId, KernelStatus } from './ikernel';
 
+import { IAjaxOptions } from './utils';
+
 
 /**
  * Notebook Identification specification.
@@ -75,10 +77,10 @@ interface INotebookSession {
   /**
    * Rename the notebook.
    */
-  renameNotebook(path: string): Promise<void>;
+  renameNotebook(path: string, ajaxOptions?: IAjaxOptions): Promise<void>;
 
   /**
    * Kill the kernel and shutdown the session.
    */
-  shutdown(): Promise<void>;
+  shutdown(ajaxOptions?: IAjaxOptions): Promise<void>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,7 +157,7 @@ function ajaxRequest(url: string, settings: IAjaxSettings, options?: IAjaxOption
     if (settings.contentType) {
       req.setRequestHeader('Content-Type', settings.contentType);
     }
-    req.timeout = options.timeout || 0;
+    if (options.timeout !== void 0) req.timeout = options.timeout;
     req.withCredentials = options.withCredentials || false;
     if (options.requestHeaders !== void 0) {
        for (var prop in options.requestHeaders) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -158,7 +158,9 @@ function ajaxRequest(url: string, settings: IAjaxSettings, options?: IAjaxOption
       req.setRequestHeader('Content-Type', settings.contentType);
     }
     if (options.timeout !== void 0) req.timeout = options.timeout;
-    req.withCredentials = options.withCredentials || false;
+    if (options.withCredentials !== void 0) {
+      req.withCredentials = options.withCredentials;
+    }
     if (options.requestHeaders !== void 0) {
        for (var prop in options.requestHeaders) {
          req.setRequestHeader(prop, (options as any).requestHeaders[prop]);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
     files: ['build/karma.js'],
     colors: true,
     singleRun: true,
-    logLevel: config.LOG_INFO
+    logLevel: config.LOG_INFO,
+    browserNoActivityTimeout: 30000,
   });
 };

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
     reporters: ['mocha'],
     preprocessors: { 'build/karma.js': ['browserify'] },
     browserify: { debug: true },
-    client: { mocha: { timeout: 10000 } },
+    client: { mocha: { timeout: 30000 } },
     files: ['build/karma.js'],
     colors: true,
     singleRun: true,

--- a/test/src/karma.ts
+++ b/test/src/karma.ts
@@ -239,9 +239,7 @@ describe('jupyter.services - Integration', () => {
         var options = { type: 'file', ext: '.ipynb' };
         contents.newUntitled('.', options).then(model0 => {
           contents.rename(model0.path, 'foo.ipynb').then(model1 => {
-            console.log("***HERE WE ARE 2");
             expect(model1.path).to.be('foo.ipynb');
-            console.log("***HERE WE ARE 3");
             contents.delete('foo.ipynb').then(done);
           });
         });

--- a/test/src/mockxhr.ts
+++ b/test/src/mockxhr.ts
@@ -90,7 +90,6 @@ class MockXMLHttpRequest {
    * automatically canceled.
    */
   set timeout(timeout: number) {
-    throw Error('Not implemented');
     this._timeout = timeout;
   }
 
@@ -121,6 +120,13 @@ class MockXMLHttpRequest {
    */
   set onreadystatechange(cb: () => void) {
     this._onReadyState = cb;
+  }
+
+  /**
+   * Set a callback for when the ready state changes.
+   */
+  set ontimeout(cb: () => void) {
+    this._onTimeout = cb;
   }
 
   /**
@@ -163,6 +169,14 @@ class MockXMLHttpRequest {
     var onRequest = MockXMLHttpRequest.onRequest;
     if (onRequest) onRequest();
     MockXMLHttpRequest.onRequest = null;
+    if (this._timeout > 0) {
+      setTimeout(() => {
+        if (this._readyState != MockXMLHttpRequest.DONE) {
+          var cb = this._onTimeout;
+          if (cb) cb();
+        }
+      }, this._timeout);
+    }
   }
 
   /**
@@ -229,4 +243,5 @@ class MockXMLHttpRequest {
   private _requestHeader: any = {};
   private _responseHeader: any = {};
   private _onReadyState: () => void = null;
+  private _onTimeout: () => void = null;
 }

--- a/test/src/testconfig.ts
+++ b/test/src/testconfig.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/config';
 
 
-import { RequestHandler, expectFailure } from './utils';
+import { RequestHandler, expectFailure, ajaxOptions } from './utils';
 
 
 describe('jupyter.services - IConfigSection', () => {
@@ -19,6 +19,14 @@ describe('jupyter.services - IConfigSection', () => {
     it('should complete properly', (done) => {
       var handler = new RequestHandler();
       getConfigSection("test", "localhost").then(config => {
+        done();
+      });
+      handler.respond(200, {});
+    });
+
+    it('should accept ajaxOptions', (done) => {
+      var handler = new RequestHandler();
+      getConfigSection("test", "localhost", ajaxOptions).then(config => {
         done();
       });
       handler.respond(200, {});
@@ -54,6 +62,19 @@ describe('jupyter.services - IConfigSection', () => {
           expect(config.data.foo).to.be('baz');
           expect(data.spam).to.be('eggs');
           expect(config.data.spam).to.be('eggs');
+          done();
+        });
+      });
+      handler.respond(200, {});
+    });
+
+    it('should accept ajaxOptions', (done) => {
+      var handler = new RequestHandler();
+      getConfigSection("test", "localhost").then(config => {
+        var update = config.update( { foo: 'baz', spam: 'eggs' }, ajaxOptions);
+        handler.respond(200, config.data );
+        return update.then((data: any) => {
+          expect(data.foo).to.be('baz');
           done();
         });
       });

--- a/test/src/testcontents.ts
+++ b/test/src/testcontents.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/contents';
 
 
-import { RequestHandler, expectFailure } from './utils';
+import { RequestHandler, ajaxOptions, expectFailure } from './utils';
 
 
 var DEFAULT_FILE: IContentsModel = {
@@ -75,6 +75,18 @@ describe('jupyter.services - Contents', () => {
       });
     });
 
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var get = contents.get("/foo", { type: "directory", name: "bar" },
+                             ajaxOptions);
+      handler.respond(200, DEFAULT_DIR);
+      return get.then((model: IContentsModel) => {
+        expect(model.content).to.be(DEFAULT_DIR.content);
+        done();
+      });
+    });
+
     it('should fail for an incorrect model', (done) => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
@@ -121,6 +133,19 @@ describe('jupyter.services - Contents', () => {
       });
     });
 
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var newDir = contents.newUntitled("/foo", { type: "directory", 
+                                                  ext: "" },
+                                        ajaxOptions);
+      handler.respond(201, DEFAULT_DIR);
+      return newDir.then((model: IContentsModel) => {
+        expect(model.content).to.be(DEFAULT_DIR.content);
+        done();
+      });
+    });
+
     it('should fail for an incorrect model', (done) => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
@@ -147,6 +172,16 @@ describe('jupyter.services - Contents', () => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
       var del = contents.delete("/foo/bar.txt");
+      handler.respond(204, { });
+      return del.then(() => {
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var del = contents.delete("/foo/bar.txt", ajaxOptions);
       handler.respond(204, { });
       return del.then(() => {
         done();
@@ -185,6 +220,18 @@ describe('jupyter.services - Contents', () => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
       var rename = contents.rename("/foo/bar.txt", "/foo/baz.txt");
+      handler.respond(200, DEFAULT_FILE);
+      return rename.then((obj: IContentsModel) => {
+        expect(obj.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var rename = contents.rename("/foo/bar.txt", "/foo/baz.txt",
+                                   ajaxOptions);
       handler.respond(200, DEFAULT_FILE);
       return rename.then((obj: IContentsModel) => {
         expect(obj.created).to.be(DEFAULT_FILE.created);
@@ -236,6 +283,18 @@ describe('jupyter.services - Contents', () => {
       });
     });
 
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var save = contents.save("/foo", { type: "file", name: "test" },
+                               ajaxOptions);
+      handler.respond(200, DEFAULT_FILE);
+      return save.then((obj: IContentsModel) => {
+        expect(obj.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
     it('should fail for an incorrect model', (done) => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
@@ -262,6 +321,18 @@ describe('jupyter.services - Contents', () => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
       var copy = contents.copy("/foo/bar.txt", "/baz");
+      handler.respond(201, DEFAULT_FILE);
+      return copy.then((obj: IContentsModel) => {
+        expect(obj.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var copy = contents.copy("/foo/bar.txt", "/baz",
+                               ajaxOptions);
       handler.respond(201, DEFAULT_FILE);
       return copy.then((obj: IContentsModel) => {
         expect(obj.created).to.be(DEFAULT_FILE.created);
@@ -302,6 +373,17 @@ describe('jupyter.services - Contents', () => {
       });
     });
 
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var checkpoint = contents.createCheckpoint("/foo/bar.txt", ajaxOptions);
+      handler.respond(201, DEFAULT_CP);
+      return checkpoint.then((obj: ICheckpointModel) => {
+        expect(obj.last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
     it('should fail for an incorrect model', (done) => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
@@ -328,6 +410,17 @@ describe('jupyter.services - Contents', () => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
       var checkpoints = contents.listCheckpoints("/foo/bar.txt");
+      handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
+      return checkpoints.then((obj: ICheckpointModel[]) => {
+        expect(obj[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var checkpoints = contents.listCheckpoints("/foo/bar.txt", ajaxOptions);
       handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
       return checkpoints.then((obj: ICheckpointModel[]) => {
         expect(obj[0].last_modified).to.be(DEFAULT_CP.last_modified);
@@ -375,6 +468,17 @@ describe('jupyter.services - Contents', () => {
       });
     });
 
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var checkpoint = contents.restoreCheckpoint("/foo/bar.txt",
+                                                  DEFAULT_CP.id, ajaxOptions);
+      handler.respond(204, { });
+      return checkpoint.then(() => {
+        done();
+      });
+    });
+
     it('should fail for an incorrect response', (done) => {
       var contents = new Contents("localhost");
       var handler = new RequestHandler();
@@ -393,6 +497,17 @@ describe('jupyter.services - Contents', () => {
       var handler = new RequestHandler();
       var checkpoint = contents.deleteCheckpoint("/foo/bar.txt",
                                                   DEFAULT_CP.id);
+      handler.respond(204, { });
+      return checkpoint.then(() => {
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var checkpoint = contents.deleteCheckpoint("/foo/bar.txt",
+                                                  DEFAULT_CP.id, ajaxOptions);
       handler.respond(204, { });
       return checkpoint.then(() => {
         done();
@@ -422,5 +537,17 @@ describe('jupyter.services - Contents', () => {
         done();
       });
     });
+
+    it('should accept ajax options', (done) => {
+      var contents = new Contents("localhost");
+      var handler = new RequestHandler();
+      var dir = contents.listContents("/foo", ajaxOptions);
+      handler.respond(200, DEFAULT_FILE);
+      return dir.then((model: IContentsModel) => {
+        expect(model.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+    });
+
   });
 });

--- a/test/src/testkernelspecs.ts
+++ b/test/src/testkernelspecs.ts
@@ -8,7 +8,7 @@ import {  IKernelSpecId, IKernelSpecIds } from '../../lib/ikernel';
 
 import { getKernelSpecs } from '../../lib/kernel';
 
-import { RequestHandler, expectFailure } from './utils';
+import { RequestHandler, ajaxOptions, expectFailure } from './utils';
 
 
 var PYTHON_SPEC: IKernelSpecId = {
@@ -37,6 +37,24 @@ describe('jupyter.services - Kernel', () => {
       var handler = new RequestHandler();
 
       var promise = getKernelSpecs('localhost');
+      var ids = {
+        'python': PYTHON_SPEC,
+        'python3': PYTHON3_SPEC
+      }
+      handler.respond(200, { 'default': 'python',
+                             'kernelspecs': ids });
+      return promise.then((specs) => {
+        var names = Object.keys(specs.kernelspecs);
+        expect(names[0]).to.be('python');
+        expect(names[1]).to.be('python3');
+        done();
+      });
+    });
+
+    it('should accept ajax options', (done) => {
+      var handler = new RequestHandler();
+
+      var promise = getKernelSpecs('localhost', ajaxOptions);
       var ids = {
         'python': PYTHON_SPEC,
         'python3': PYTHON3_SPEC

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -8,6 +8,8 @@ import encoding = require('text-encoding');
 
 import { MockXMLHttpRequest } from './mockxhr';
 
+import { IAjaxOptions } from '../../lib/index';
+
 
 // stub for node global
 declare var global: any;
@@ -69,4 +71,18 @@ function expectFailure(promise: Promise<any>, done: () => void, message: string)
 export
 function doLater(cb: () => void): void {
   Promise.resolve().then(cb);
+}
+
+
+/**
+ * Optional ajax arguments.
+ */
+export
+var ajaxOptions: IAjaxOptions = {
+  timeout: 10,
+  requestHeaders: { foo: 'bar', fizz: 'buzz' },
+  async: true,
+  withCredentials: true,
+  user: 'foo',
+  password: 'bar'
 }


### PR DESCRIPTION
Fixes #31, adding optional Ajax parameters to all methods and functions with Ajax calls.

```typescript
/**
 * Options for AJAX calls.
 */
export
interface IAjaxOptions {
  timeout?: number;
  requestHeaders?: { [key: string]: string; };
  async?: boolean;
  withCredentials?: boolean;
  user?: string;
  password?: string;
}
```