### PR TITLE
provide default values for baseUrl, wsUrl

### DIFF
--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -21,11 +21,12 @@ interface IKernelOptions {
 
   /**
    * The root url of the kernel server.
+   * Default is location.origin in browsers, notebook-server default otherwise.
    */
-  baseUrl: string;
+  baseUrl?: string;
 
   /**
-   * The url to access websockets. 
+   * The url to access websockets, if different from baseUrl.
    */
   wsUrl?: string;
 

--- a/test/src/karma.ts
+++ b/test/src/karma.ts
@@ -12,7 +12,6 @@ import {
 
 
 var BASEURL = 'http://localhost:8888';
-var WSURL = 'ws://localhost:8888';
 
 
 describe('jupyter.services - Integration', () => {
@@ -26,7 +25,6 @@ describe('jupyter.services - Integration', () => {
         console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {
@@ -51,7 +49,6 @@ describe('jupyter.services - Integration', () => {
         console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {
@@ -82,7 +79,6 @@ describe('jupyter.services - Integration', () => {
         console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {
@@ -112,7 +108,6 @@ describe('jupyter.services - Integration', () => {
       getKernelSpecs(BASEURL).then((kernelSpecs) => {
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           kernelName: kernelSpecs.default,
           notebookPath: 'Untitled1.ipynb'
         }
@@ -153,7 +148,6 @@ describe('jupyter.services - Integration', () => {
       getKernelSpecs(BASEURL).then((kernelSpecs) => {
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {
@@ -194,7 +188,6 @@ describe('jupyter.services - Integration', () => {
       getKernelSpecs(BASEURL).then((kernelSpecs) => {
         var options = {
           baseUrl: BASEURL,
-          wsUrl: WSURL,
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -51,7 +51,6 @@ const EXAMPLE_KERNEL_INFO: IKernelInfo = {
 
 const KERNEL_OPTIONS: IKernelOptions = {
   baseUrl: 'http://localhost:8888',
-  wsUrl: 'ws://localhost:8888',
   name: 'test',
   username: 'testUser'
 }


### PR DESCRIPTION
In existing use cases, wsUrl can never deviate from the default value, so it doesn't make sense to require it to be specified.