### PR TITLE
Execute defaults

### DIFF
--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -633,10 +633,11 @@ class Kernel implements IKernel {
       session: this._clientId
     }
     var defaults = {
-      silent : true,
-      store_history : false,
+      silent : false,
+      store_history : true,
       user_expressions : {},
-      allow_stdin : false
+      allow_stdin : true,
+      stop_on_error : false
     };
     contents = utils.extend(defaults, contents);
     var msg = createKernelMessage(options, contents);


### PR DESCRIPTION
This brings the execute command defaults into alignment with the message spec documentation at http://jupyter-client.readthedocs.org/en/latest/messaging.html#execute.

@ellisonbg - you changed the defaults in the kernel.js code away from these in https://github.com/jupyter/notebook/commit/f306423c7ea3bc60735a8bfb4f5f2cc60dc36b97.  Do you recall why you did this, and do you have comments about changing it back in jupyter-js-services?