### PR TITLE
Add "findby" functions for sessions and kernels

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,8 +50,7 @@ interface IConfigSection {
  * @returns A Promise that is fulfilled with the config section is loaded.
  */
 export
-function getConfigSection(sectionName: string, baseUrl: string, ajaxSettings?: IAjaxSettings): Promise<IConfigSection> {
-  baseUrl = baseUrl || utils.getBaseUrl();
+function getConfigSection(sectionName: string, baseUrl?: string, ajaxSettings?: IAjaxSettings): Promise<IConfigSection> {
   var section = new ConfigSection(sectionName, baseUrl, ajaxSettings);
   return section.load();
 }
@@ -65,7 +64,7 @@ class ConfigSection implements IConfigSection {
   /**
    * Create a config section.
    */
-  constructor(sectionName: string, baseUrl: string, ajaxSettings?: IAjaxSettings) {
+  constructor(sectionName: string, baseUrl?: string, ajaxSettings?: IAjaxSettings) {
     baseUrl = baseUrl || utils.getBaseUrl();
     if (ajaxSettings) this.ajaxSettings = ajaxSettings;
     this._url = utils.urlPathJoin(baseUrl, SERVICE_CONFIG_URL,

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -296,7 +296,7 @@ class ContentsManager implements IContentsManager {
    *
    * @param ajaxSettings - Optional initial ajax settings.
    */
-  constructor(baseUrl: string, ajaxSettings?: IAjaxSettings) {
+  constructor(baseUrl?: string, ajaxSettings?: IAjaxSettings) {
     baseUrl = baseUrl || utils.getBaseUrl();
     if (ajaxSettings) this.ajaxSettings = ajaxSettings;
     this._apiUrl = utils.urlPathJoin(baseUrl, SERVICE_CONTENTS_URL);

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -822,6 +822,11 @@ interface IKernelManager {
   startNew(options?: IKernelOptions): Promise<IKernel>;
 
   /**
+   * Find a kernel by id.
+   */
+  findById(id: string, options?: IKernelOptions): Promise<IKernelId>;
+
+  /**
    * Connect to an existing kernel.
    */
   connectTo(id: string, options?: IKernelOptions): Promise<IKernel>;

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -116,6 +116,16 @@ interface INotebookSessionManager {
   startNew(options: ISessionOptions): Promise<INotebookSession>;
 
   /**
+   * Find a session by id.
+   */
+  findById(id: string, options?: ISessionOptions): Promise<ISessionId>;
+
+  /**
+   * Find a session by notebook path.
+   */
+  findByPath(id: string, options?: ISessionOptions): Promise<ISessionId>;
+
+  /**
    * Connect to a running notebook session.
    */
   connectTo(id: string, options?: ISessionOptions): Promise<INotebookSession>;

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -233,14 +233,15 @@ function listRunningKernels(options?: IKernelOptions): Promise<IKernelId[]> {
  * #### Notes
  * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter-js-services/master/rest_api.yaml#!/kernels) and validates the response model.
  *
+ * If no options are given or the kernel name is not given, the 
+ * default kernel will by started by the server.
+ *
  * Wraps the result in a Kernel object. The promise is fulfilled
  * when the kernel is started by the server, otherwise the promise is rejected.
  */
 export
-function startNewKernel(options: IKernelOptions): Promise<IKernel> {
-  if (options.name === void 0) {
-    return Promise.reject(new Error('Must specify a kernel name'));
-  }
+function startNewKernel(options?: IKernelOptions): Promise<IKernel> {
+  options = options || {};
   let baseUrl = options.baseUrl || utils.getBaseUrl();
   let url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL);
   let ajaxSettings = utils.copy(options.ajaxSettings) || {};

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -140,8 +140,8 @@ class KernelManager implements IKernelManager {
 export
 function findKernelById(id: string, options?: IKernelOptions): Promise<IKernelId> {
   let kernels = Private.runningKernels;
-  for (let kernelId in kernels.keys()) {
-    let kernel = kernels.get(kernelId);
+  for (let kernelId in kernels) {
+    let kernel = kernels[kernelId];
     if (kernelId === id) {
       let result = { id: kernel.id, name: kernel.name };
       return Promise.resolve(result);
@@ -276,7 +276,7 @@ function startNewKernel(options: IKernelOptions): Promise<IKernel> {
  */
 export
 function connectToKernel(id: string, options?: IKernelOptions): Promise<IKernel> {
-  let kernel = Private.runningKernels.get(id);
+  let kernel = Private.runningKernels[id];
   if (kernel) {
     return Promise.resolve(kernel);
   }
@@ -329,7 +329,7 @@ class Kernel implements IKernel {
     this._commPromises = new Map<string, Promise<IComm>>();
     this._comms = new Map<string, IComm>();
     this._createSocket();
-    Private.runningKernels.set(this._id, this);
+    Private.runningKernels[this._id] = this;
   }
 
   /**
@@ -443,7 +443,7 @@ class Kernel implements IKernel {
     this._status = KernelStatus.Dead;
     this._targetRegistry = null;
     clearSignalData(this);
-    Private.runningKernels.delete(this._id);
+    delete Private.runningKernels[this._id];
   }
 
   /**
@@ -1099,7 +1099,7 @@ namespace Private {
    * A module private store for running kernels.
    */
   export
-  const runningKernels = new Map<string, Kernel>();
+  const runningKernels: { [key: string]: IKernel; } = Object.create(null);
 
   /**
    * Restart a kernel.

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -134,7 +134,7 @@ class KernelManager implements IKernelManager {
  *
  * Otherwise, if `options` are given, we attempt to find to the existing
  * kernel.
- * The promise is fulfilled when the kernel is found, 
+ * The promise is fulfilled when the kernel is found,
  * otherwise the promise is rejected.
  */
 export
@@ -233,7 +233,7 @@ function listRunningKernels(options?: IKernelOptions): Promise<IKernelId[]> {
  * #### Notes
  * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter-js-services/master/rest_api.yaml#!/kernels) and validates the response model.
  *
- * If no options are given or the kernel name is not given, the 
+ * If no options are given or the kernel name is not given, the
  * default kernel will by started by the server.
  *
  * Wraps the result in a Kernel object. The promise is fulfilled

--- a/src/session.ts
+++ b/src/session.ts
@@ -153,6 +153,10 @@ function listRunningSessions(options?: ISessionOptions): Promise<ISessionId[]> {
  *
  * #### Notes
  * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter-js-services/master/rest_api.yaml#!/sessions), and validates the response.
+ * 
+ * A notebook path must be provided.  If a kernel id is given, it will
+ * connect to an existing kernel.  If no kernel id or name is given,
+ * the server will start the default kernel type.
  *
  * The promise is fulfilled on a valid response and rejected otherwise.
 
@@ -289,7 +293,8 @@ class NotebookSession implements INotebookSession {
     this._id = id;
     this._notebookPath = options.notebookPath;
     this._kernel = kernel;
-    this._url = utils.urlPathJoin(options.baseUrl, SESSION_SERVICE_URL, this._id);
+    let baseUrl = options.baseUrl || utils.getBaseUrl();
+    this._url = utils.urlPathJoin(baseUrl, SESSION_SERVICE_URL, this._id);
     this._kernel.statusChanged.connect(this.onKernelStatus, this);
     this._kernel.unhandledMessage.connect(this.onUnhandledMessage, this);
     this._options = utils.copy(options);

--- a/src/session.ts
+++ b/src/session.ts
@@ -186,8 +186,8 @@ function startNewSession(options: ISessionOptions): Promise<INotebookSession> {
 export
 function findSessionById(id: string, options?: ISessionOptions): Promise<ISessionId> {
   let sessions = Private.runningSessions;
-  for (let sessionId in sessions.keys()) {
-    let session = sessions.get(sessionId);
+  for (let sessionId in sessions) {
+    let session = sessions[sessionId];
     if (sessionId === id) {
       let sessionId = {
         id,
@@ -222,8 +222,8 @@ function findSessionById(id: string, options?: ISessionOptions): Promise<ISessio
 export
 function findSessionByPath(path: string, options?: ISessionOptions): Promise<ISessionId> {
   let sessions = Private.runningSessions;
-  for (let id in sessions.keys()) {
-    let session = sessions.get(id);
+  for (let id in sessions) {
+    let session = sessions[id];
     if (session.notebookPath === path) {
       let sessionId = {
         id,
@@ -262,7 +262,7 @@ function findSessionByPath(path: string, options?: ISessionOptions): Promise<ISe
  */
 export
 function connectToSession(id: string, options?: ISessionOptions): Promise<INotebookSession> {
-  let session = Private.runningSessions.get(id);
+  let session = Private.runningSessions[id];
   if (session) {
     return Promise.resolve(session);
   }
@@ -397,7 +397,7 @@ class NotebookSession implements INotebookSession {
     this._options = null;
     this._kernel = null;
     clearSignalData(this);
-    Private.runningSessions.delete(this._id);
+    delete Private.runningSessions[this._id];
   }
 
   /**
@@ -562,7 +562,7 @@ namespace Private {
    * The running sessions.
    */
   export
-  const runningSessions = new Map<string, NotebookSession>();
+  const runningSessions: { [key: string]: INotebookSession; } = Object.create(null);
 
   /**
    * Create a new session, or return an existing session if a session if
@@ -617,7 +617,7 @@ namespace Private {
   function createSession(sessionId: ISessionId, options: ISessionOptions): Promise<NotebookSession> {
     return createKernel(sessionId, options).then(kernel => {
        let session = new NotebookSession(options, sessionId.id, kernel);
-       runningSessions.set(session.id, session);
+       runningSessions[session.id] = session;
        return session;
     }).catch(error => {
       return typedThrow('Session failed to start: ' + error.message);

--- a/src/session.ts
+++ b/src/session.ts
@@ -153,7 +153,7 @@ function listRunningSessions(options?: ISessionOptions): Promise<ISessionId[]> {
  *
  * #### Notes
  * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter-js-services/master/rest_api.yaml#!/sessions), and validates the response.
- * 
+ *
  * A notebook path must be provided.  If a kernel id is given, it will
  * connect to an existing kernel.  If no kernel id or name is given,
  * the server will start the default kernel type.
@@ -184,7 +184,7 @@ function startNewSession(options: ISessionOptions): Promise<INotebookSession> {
  *
  * Otherwise, if `options` are given, we attempt to find to the existing
  * session.
- * The promise is fulfilled when the session is found, 
+ * The promise is fulfilled when the session is found,
  * otherwise the promise is rejected.
  */
 export
@@ -217,7 +217,7 @@ function findSessionById(id: string, options?: ISessionOptions): Promise<ISessio
  *
  * Otherwise, if `options` are given, we attempt to find to the existing
  * session using [listRunningSessions].
- * The promise is fulfilled when the session is found, 
+ * The promise is fulfilled when the session is found,
  * otherwise the promise is rejected.
  *
  * If the session was not already started and no `options` are given,
@@ -258,7 +258,7 @@ function findSessionByPath(path: string, options?: ISessionOptions): Promise<ISe
  *
  * Otherwise, if `options` are given, we attempt to connect to the existing
  * session.
- * The promise is fulfilled when the session is ready on the server, 
+ * The promise is fulfilled when the session is ready on the server,
  * otherwise the promise is rejected.
  *
  * If the session was not already started and no `options` are given,

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -4,6 +4,7 @@
 import subprocess
 import sys
 import argparse
+import re
 import threading
 
 KARMA_PORT = 9876
@@ -22,6 +23,7 @@ def start_notebook():
             continue
         print(line)
         if 'Jupyter Notebook is running at:' in line:
+            base_url = re.search('(http.*?)$', line).groups()[0]
             break
 
     while 1:
@@ -43,11 +45,12 @@ def start_notebook():
     thread.setDaemon(True)
     thread.start()
 
-    return nb_server
+    return nb_server, base_url
 
 
-def run_mocha(options):
-    mocha_command = ['mocha', '--timeout', '20000', 'build/integration.js']
+def run_mocha(options, base_url):
+    mocha_command = ['mocha', '--timeout', '20000', 'build/integration.js',
+                     '--baseUrl=%s' % base_url]
     return subprocess.check_call(mocha_command, stderr=subprocess.STDOUT)
 
 
@@ -61,10 +64,10 @@ if __name__ == '__main__':
                            help="Whether to enter debug mode in Karma")
     options = argparser.parse_args(sys.argv[1:])
 
-    nb_server = start_notebook()
+    nb_server, base_url = start_notebook()
 
     try:
-        resp = run_mocha(options)
+        resp = run_mocha(options, base_url)
     except subprocess.CalledProcessError:
         resp = 1
     finally:

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -10,7 +10,7 @@ import * as NodeWebSocket
   from 'ws';
 
 
-// stub for node global
+// Stub for node global.
 declare var global: any;
 global.XMLHttpRequest = NodeXMLHttpRequest;
 global.WebSocket = NodeWebSocket;
@@ -22,20 +22,16 @@ import {
 } from '../../lib';
 
 
-var BASEURL = 'http://localhost:8888';
-
-
 describe('jupyter.services - Integration', () => {
 
   describe('Kernel', () => {
 
     it('should start, restart and get kernel info', (done) => {
       // get info about the available kernels and connect to one
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
+      getKernelSpecs().then((kernelSpecs) => {
         console.log('default spec:', kernelSpecs.default);
         console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
-        var options = {
-          baseUrl: BASEURL,
+        let options = {
           name: kernelSpecs.default
         }
         startNewKernel(options).then((kernel) => {
@@ -55,29 +51,21 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should connect to existing kernel and list running kernels', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        console.log('default spec:', kernelSpecs.default);
-        console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
-        var options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default
-        }
-        startNewKernel(options).then((kernel) => {
-          console.log('Hello Kernel: ', kernel.name, kernel.id);
-          // should grab the same kernel object
-          connectToKernel(kernel.id, options).then((kernel2) => {
-            console.log('Should have gotten the same kernel');
-            if (kernel2.clientId !== kernel.clientId) {
-              throw Error('Did not reuse kernel');
+      startNewKernel().then((kernel) => {
+        console.log('Hello Kernel: ', kernel.name, kernel.id);
+        // should grab the same kernel object
+        connectToKernel(kernel.id).then((kernel2) => {
+          console.log('Should have gotten the same kernel');
+          if (kernel2.clientId !== kernel.clientId) {
+            throw Error('Did not reuse kernel');
+          }
+          listRunningKernels().then((kernels) => {
+            if (!kernels.length) {
+              throw Error('Should be one at least one running kernel');
             }
-            listRunningKernels({ baseUrl: BASEURL }).then((kernels) => {
-              if (!kernels.length) {
-                throw Error('Should be one at least one running kernel');
-              }
-              kernel2.kernelInfo().then(() => {
-                console.log('Final request');
-                done();
-              });
+            kernel2.kernelInfo().then(() => {
+              console.log('Final request');
+              kernel.shutdown().then(() => { done(); });
             });
           });
         });
@@ -85,27 +73,19 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should handle other kernel messages', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        console.log('default spec:', kernelSpecs.default);
-        console.log('available specs', Object.keys(kernelSpecs.kernelspecs));
-        var options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default
-        }
-        startNewKernel(options).then((kernel) => {
-          console.log('Kernel started');
-          kernel.complete({ code: 'impor', cursor_pos: 4 }).then((completions) => {
-            console.log('Got completions: ', completions.matches);
-            kernel.inspect({ code: 'hex', cursor_pos: 2, detail_level: 0 }).then((info) => {
-              console.log('Got inspect: ', info.data);
-              kernel.isComplete({ code: 'from numpy import (\n' }).then((result) => {
-                console.log('Got isComplete: ', result.status);
-                var future = kernel.execute({ code: 'a = 1\n' });
-                future.onDone = () => {
-                  console.log('Execute finished');
-                  done();
-                }
-              });
+      startNewKernel().then((kernel) => {
+        console.log('Kernel started');
+        kernel.complete({ code: 'impor', cursor_pos: 4 }).then((completions) => {
+          console.log('Got completions: ', completions.matches);
+          kernel.inspect({ code: 'hex', cursor_pos: 2, detail_level: 0 }).then((info) => {
+            console.log('Got inspect: ', info.data);
+            kernel.isComplete({ code: 'from numpy import (\n' }).then((result) => {
+              console.log('Got isComplete: ', result.status);
+              let future = kernel.execute({ code: 'a = 1\n' });
+              future.onDone = () => {
+                console.log('Execute finished');
+                kernel.shutdown().then(() => { done(); });
+              }
             });
           });
         });
@@ -116,34 +96,28 @@ describe('jupyter.services - Integration', () => {
   describe('Session', () => {
 
     it('should start, connect to existing session and list running sessions', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var options = {
-          baseUrl: BASEURL,
-          kernelName: kernelSpecs.default,
-          notebookPath: 'Untitled1.ipynb'
-        }
-        startNewSession(options).then((session) => {
-          console.log('Hello Session: ', session.id, session.notebookPath);
-          session.renameNotebook('Untitled2.ipynb').then(() => {
-            expect(session.notebookPath).to.be('Untitled2.ipynb');
+      let options = { notebookPath: 'Untitled1.ipynb' };
+      startNewSession(options).then((session) => {
+        console.log('Hello Session: ', session.id, session.notebookPath);
+        session.renameNotebook('Untitled2.ipynb').then(() => {
+          expect(session.notebookPath).to.be('Untitled2.ipynb');
 
-            // should grab the same session object
-            connectToSession(session.id, options).then((session2) => {
-              console.log('Should have gotten the same kernel');
-              if (session2.kernel.clientId !== session.kernel.clientId) {
-                throw Error('Did not reuse session');
+          // should grab the same session object
+          connectToSession(session.id, options).then((session2) => {
+            console.log('Should have gotten the same kernel');
+            if (session2.kernel.clientId !== session.kernel.clientId) {
+              throw Error('Did not reuse session');
+            }
+
+            listRunningSessions().then((sessions) => {
+              if (!sessions.length) {
+                throw Error('Should be one at least one running session');
               }
-
-              listRunningSessions({ baseUrl: BASEURL}).then((sessions) => {
-                if (!sessions.length) {
-                  throw Error('Should be one at least one running session');
-                }
-                session2.kernel.interrupt().then(() => {
-                  console.log('Got interrupt');
-                  session2.shutdown().then(() => {
-                    console.log('Got shutdown');
-                    done();
-                  });
+              session2.kernel.interrupt().then(() => {
+                console.log('Got interrupt');
+                session2.shutdown().then(() => {
+                  console.log('Got shutdown');
+                  done();
                 });
               });
             });
@@ -153,64 +127,39 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should connect to an existing kernel', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        let options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default,
+      startNewKernel().then(kernel => {
+        let sessionOptions = {
+          kernelId: kernel.id,
+          notebookPath: 'Untitled1.ipynb'
         }
-        startNewKernel(options).then(kernel => {
-          let sessionOptions = {
-            baseUrl: BASEURL,
-            kernelId: kernel.id,
-            notebookPath: 'Untitled1.ipynb'
-          }
-          startNewSession(sessionOptions).then(session => {
-            console.log('Hello Session: ', session.id);
-            expect(session.kernel.id).to.be(kernel.id);
-            done();
-          });
+        startNewSession(sessionOptions).then(session => {
+          console.log('Hello Session: ', session.id);
+          expect(session.kernel.id).to.be(kernel.id);
+          session.shutdown().then(() => { done(); });
         });
       });
     });
 
     it('should be able to switch to an existing kernel by id', (done) => {
-      // get info about the available kernels and connect to one
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        let options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default
-        }
-        startNewKernel(options).then(kernel => {
-          let sessionOptions = {
-            baseUrl: BASEURL,
-            kernelName: kernelSpecs.default,
-            notebookPath: 'Untitled1.ipynb'
-          }
-          startNewSession(sessionOptions).then(session => {
-            session.changeKernel({ id: kernel.id }).then(newKernel => {
-              expect(newKernel.id).to.be(kernel.id);
-              done();
-            });
+      startNewKernel().then(kernel => {
+        let sessionOptions = { notebookPath: 'Untitled1.ipynb' };
+        startNewSession(sessionOptions).then(session => {
+          session.changeKernel({ id: kernel.id }).then(newKernel => {
+            expect(newKernel.id).to.be(kernel.id);
+            session.shutdown().then(() => { done(); });
           });
         });
       });
     });
 
     it('should be able to switch to a new kernel by name', (done) => {
-      // get info about the available kernels and connect to one
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        let kernelName = kernelSpecs.default;
-        let options = {
-          baseUrl: BASEURL,
-          kernelName,
-          notebookPath: 'Untitled1.ipynb'
-        }
-        startNewSession(options).then(session => {
-          let id = session.kernel.id;
-          session.changeKernel({ name: kernelName }).then(newKernel => {
-            expect(newKernel.id).to.not.be(id);
-            done();
-          });
+      // Get info about the available kernels and connect to one.
+      let options = { notebookPath: 'Untitled1.ipynb' };
+      startNewSession(options).then(session => {
+        let id = session.kernel.id;
+        session.changeKernel({ name: session.kernel.name }).then(newKernel => {
+          expect(newKernel.id).to.not.be(id);
+          session.shutdown().then(() => { done(); });
         });
       });
     });
@@ -220,40 +169,33 @@ describe('jupyter.services - Integration', () => {
   describe('Comm', () => {
 
     it('should start a comm from the server end', (done) => {
-      // get info about the available kernels and connect to one
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default
-        }
-        startNewKernel(options).then((kernel) => {
-          kernel.registerCommTarget('test', (comm, msg) => {
-            let content = msg.content;
-            expect(content.target_name).to.be('test');
-            comm.onMsg = (msg) => {
-              expect(msg.content.data).to.be('hello');
-              comm.send('0');
-              comm.send('1');
-              comm.send('2');
-            }
-            comm.onClose = (msg) => {
-              expect(msg.content.data).to.eql(['0', '1', '2']);
-              done();
-            }
-          });
-          var code = [
-            "from ipykernel.comm import Comm",
-            "comm = Comm(target_name='test')",
-            "comm.send(data='hello')",
-            "msgs = []",
-            "def on_msg(msg):",
-            "    msgs.append(msg['content']['data'])",
-            "    if len(msgs) == 3:",
-            "       comm.close(msgs)",
-            "comm.on_msg(on_msg)"
-          ].join('\n')
-          kernel.execute({ code: code });
+      startNewKernel().then((kernel) => {
+        kernel.registerCommTarget('test', (comm, msg) => {
+          let content = msg.content;
+          expect(content.target_name).to.be('test');
+          comm.onMsg = (msg) => {
+            expect(msg.content.data).to.be('hello');
+            comm.send('0');
+            comm.send('1');
+            comm.send('2');
+          }
+          comm.onClose = (msg) => {
+            expect(msg.content.data).to.eql(['0', '1', '2']);
+            done();
+          }
         });
+        let code = [
+          "from ipykernel.comm import Comm",
+          "comm = Comm(target_name='test')",
+          "comm.send(data='hello')",
+          "msgs = []",
+          "def on_msg(msg):",
+          "    msgs.append(msg['content']['data'])",
+          "    if len(msgs) == 3:",
+          "       comm.close(msgs)",
+          "comm.on_msg(on_msg)"
+        ].join('\n')
+        kernel.execute({ code: code });
       });
     });
   });
@@ -261,20 +203,14 @@ describe('jupyter.services - Integration', () => {
   describe('Config', () => {
 
     it('should get a config section on the server and update it', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var options = {
-          baseUrl: BASEURL,
-          name: kernelSpecs.default
-        }
-        startNewKernel(options).then((kernel) => {
-          getConfigSection('notebook', BASEURL).then(section => {
-            var defaults = { default_cell_type: 'code' };
-            var config = new ConfigWithDefaults(section, defaults, 'Notebook');
-            expect(config.get('default_cell_type')).to.be('code');
-            config.set('foo', 'bar').then(() => {
-              expect(config.get('foo')).to.be('bar');
-              done();
-            });
+      startNewKernel().then((kernel) => {
+        getConfigSection('notebook').then(section => {
+          let defaults = { default_cell_type: 'code' };
+          let config = new ConfigWithDefaults(section, defaults, 'Notebook');
+          expect(config.get('default_cell_type')).to.be('code');
+          config.set('foo', 'bar').then(() => {
+            expect(config.get('foo')).to.be('bar');
+            done();
           });
         });
       });
@@ -285,65 +221,56 @@ describe('jupyter.services - Integration', () => {
   describe('ContentManager', () => {
 
     it('should list a directory and get the file contents', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var contents = new ContentsManager(BASEURL);
-        contents.listContents('src').then(listing => {
-          var content = listing.content as any;
-          for (var i = 0; i < content.length; i++) {
-            if (content[i].type === 'file') {
-              contents.get(content[i].path, { type: "file" }).then(msg => {
-                expect(msg.path).to.be(content[i].path);
-                done();
-              });
-              break;
-            }
+      let contents = new ContentsManager();
+      contents.listContents('src').then(listing => {
+        let content = listing.content as any;
+        for (let i = 0; i < content.length; i++) {
+          if (content[i].type === 'file') {
+            contents.get(content[i].path, { type: "file" }).then(msg => {
+              expect(msg.path).to.be(content[i].path);
+              done();
+            });
+            break;
           }
-        });
+        }
       });
     });
 
     it('should create a new file, rename it, and delete it', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var contents = new ContentsManager(BASEURL);
-        var options = { type: 'file', ext: '.ipynb' };
-        contents.newUntitled('.', options).then(model0 => {
-          contents.rename(model0.path, 'foo.ipynb').then(model1 => {
-            expect(model1.path).to.be('foo.ipynb');
-            contents.delete('foo.ipynb').then(done);
-          });
+      let contents = new ContentsManager();
+      let options = { type: 'file', ext: '.ipynb' };
+      contents.newUntitled('.', options).then(model0 => {
+        contents.rename(model0.path, 'foo.ipynb').then(model1 => {
+          expect(model1.path).to.be('foo.ipynb');
+          contents.delete('foo.ipynb').then(done);
         });
       });
     });
 
     it('should create a file by name and delete it', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var contents = new ContentsManager(BASEURL);
-        var options = { type: 'file', content: '', format: 'text' };
-        contents.save('baz.txt', options).then(model0 => {
-          contents.delete('baz.txt').then(done);
-        });
+      let contents = new ContentsManager();
+      let options = { type: 'file', content: '', format: 'text' };
+      contents.save('baz.txt', options).then(model0 => {
+        contents.delete('baz.txt').then(done);
       });
     });
 
     it('should exercise the checkpoint API', (done) => {
-      getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
-        var contents = new ContentsManager(BASEURL);
-        var options = { type: 'file', contents: '' };
-        contents.save('baz.txt', options).then(model0 => {
-          contents.createCheckpoint('baz.txt').then(checkpoint => {
-            contents.listCheckpoints('baz.txt').then(checkpoints => {
-              expect(checkpoints[0]).to.eql(checkpoint);
-              contents.restoreCheckpoint('baz.txt', checkpoint.id).then(() => {
-                contents.deleteCheckpoint('baz.txt', checkpoint.id).then(() => {
-                  contents.delete('baz.txt').then(done);
-                });
+      let contents = new ContentsManager();
+      let options = { type: 'file', contents: '' };
+      contents.save('baz.txt', options).then(model0 => {
+        contents.createCheckpoint('baz.txt').then(checkpoint => {
+          contents.listCheckpoints('baz.txt').then(checkpoints => {
+            expect(checkpoints[0]).to.eql(checkpoint);
+            contents.restoreCheckpoint('baz.txt', checkpoint.id).then(() => {
+              contents.deleteCheckpoint('baz.txt', checkpoint.id).then(() => {
+                contents.delete('baz.txt').then(done);
               });
             });
           });
         });
       });
     });
-
-
   });
+
 });

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -156,8 +156,7 @@ describe('jupyter.services - Integration', () => {
       getKernelSpecs({ baseUrl: BASEURL }).then((kernelSpecs) => {
         let options = {
           baseUrl: BASEURL,
-          kernelName: kernelSpecs.default,
-          notebookPath: 'Untitled1.ipynb'
+          name: kernelSpecs.default,
         }
         startNewKernel(options).then(kernel => {
           let sessionOptions = {
@@ -167,6 +166,7 @@ describe('jupyter.services - Integration', () => {
           }
           startNewSession(sessionOptions).then(session => {
             console.log('Hello Session: ', session.id);
+            expect(session.kernel.id).to.be(kernel.id);
             done();
           });
         });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   KernelManager, connectToKernel, createKernelMessage, getKernelSpecs,
-  listRunningKernels, startNewKernel
+  listRunningKernels, startNewKernel, findKernelById
 } from '../../lib/kernel';
 
 import {
@@ -213,6 +213,23 @@ describe('jupyter.services - kernel', () => {
         });
       });
 
+    });
+
+  });
+
+  describe('findKernelById()', () => {
+
+    it('should find an existing kernel by id', (done) => {
+      let manager = new KernelManager(KERNEL_OPTIONS);
+      let id = uuid();
+      let tester = new KernelTester(() => {
+        tester.respond(200, { id: id, name: KERNEL_OPTIONS.name });
+      });
+      manager.findById(id).then(newKernel => {
+        expect(newKernel.name).to.be(KERNEL_OPTIONS.name);
+        expect(newKernel.id).to.be(id);
+        done();
+      });
     });
 
   });
@@ -1154,6 +1171,25 @@ describe('jupyter.services - kernel', () => {
           });
         });
 
+      });
+
+    });
+
+    describe('#findById()', () => {
+
+      it('should find an existing kernel by id', (done) => {
+        let manager = new KernelManager(KERNEL_OPTIONS);
+        let id = uuid();
+        let tester = new KernelTester(() => {
+          tester.respond(201, { id: id, name: KERNEL_OPTIONS.name });
+        });
+        manager.startNew().then(kernel => {
+          manager.findById(id).then(newKernel => {
+            expect(newKernel.name).to.be(kernel.name);
+            expect(newKernel.id).to.be(kernel.id);
+            done();
+          });
+        });
       });
 
     });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -887,9 +887,9 @@ describe('jupyter.services - kernel', () => {
             }
             if (kernel.status === KernelStatus.Idle) {
               expect(called).to.be(false);
-              promise.then(() => { 
+              promise.then(() => {
                 expect(called).to.be(true);
-                done(); 
+                done();
               });
             }
           });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -222,7 +222,7 @@ describe('jupyter.services - kernel', () => {
     it('should reuse an exisiting kernel', (done) => {
       let id = uuid();
       let tester = new KernelTester(() => {
-        tester.respond(200, [{ id: id, name: KERNEL_OPTIONS.name }]);
+        tester.respond(200, { id: id, name: KERNEL_OPTIONS.name });
       });
       connectToKernel(id, KERNEL_OPTIONS).then(kernel => {
         connectToKernel(id).then(newKernel => {
@@ -236,7 +236,7 @@ describe('jupyter.services - kernel', () => {
     it('should connect to a running kernel if given kernel options', (done) => {
       let id = uuid();
       let tester = new KernelTester(() => {
-        tester.respond(200, [{ id: id, name: KERNEL_OPTIONS.name }]);
+        tester.respond(200, { id: id, name: KERNEL_OPTIONS.name });
       });
       connectToKernel(id, KERNEL_OPTIONS).then(kernel => {
         expect(kernel.name).to.be(KERNEL_OPTIONS.name);
@@ -248,7 +248,7 @@ describe('jupyter.services - kernel', () => {
     it('should accept ajax options', (done) => {
       let id = uuid();
       let tester = new KernelTester(() => {
-        tester.respond(200, [{ id: id, name: KERNEL_OPTIONS.name }]);
+        tester.respond(200, { id: id, name: KERNEL_OPTIONS.name });
       });
       connectToKernel(id, AJAX_KERNEL_OPTIONS).then(kernel => {
         expect(kernel.name).to.be(KERNEL_OPTIONS.name);
@@ -257,19 +257,12 @@ describe('jupyter.services - kernel', () => {
       });
     });
 
-
-    it('should fail if no existing kernel and no options', (done) => {
-      let tester = new KernelTester();
-      let id = uuid();
-      let kernelPromise = connectToKernel(id);
-      expectFailure(kernelPromise, done, 'Please specify kernel options');
-    });
-
     it('should fail if no running kernel available', (done) => {
       let id = uuid();
       let tester = new KernelTester(() => {
-        tester.respond(200, [{ id: uuid(), name: KERNEL_OPTIONS.name }]);
+        tester.respond(400, { });
       });
+      debugger;
       let kernelPromise = connectToKernel(id, KERNEL_OPTIONS);
       expectFailure(kernelPromise, done, 'No running kernel with id: ' + id);
     });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -135,8 +135,8 @@ describe('jupyter.services - session', () => {
         if (request.method === 'POST') {
           tester.respond(201, sessionId);
         } else {
-          tester.respond(200, [ { name: sessionId.kernel.name,
-                                  id: sessionId.kernel.id }]);
+          tester.respond(200, { name: sessionId.kernel.name,
+                                  id: sessionId.kernel.id });
         }
       });
       let options = createSessionOptions(sessionId);
@@ -156,8 +156,8 @@ describe('jupyter.services - session', () => {
           if (request.method === 'POST') {
             tester.respond(201, sessionId);
           } else {
-            tester.respond(200, [ { name: sessionId.kernel.name,
-                                    id: sessionId.kernel.id }]);
+            tester.respond(200, { name: sessionId.kernel.name,
+                                    id: sessionId.kernel.id });
           }
         };
         let options = createSessionOptions(sessionId);
@@ -174,8 +174,8 @@ describe('jupyter.services - session', () => {
         if (request.method === 'POST') {
           tester.respond(201, sessionId);
         } else {
-          tester.respond(200, [ { name: sessionId.kernel.name,
-                                  id: sessionId.kernel.id }]);
+          tester.respond(200, { name: sessionId.kernel.name,
+                                  id: sessionId.kernel.id });
         }
       });
       let options = createSessionOptions(sessionId);
@@ -191,8 +191,8 @@ describe('jupyter.services - session', () => {
         if (request.method === 'POST') {
           tester.respond(201, sessionId);
         } else {
-          tester.respond(200, [ { name: sessionId.kernel.name,
-                                  id: sessionId.kernel.id }]);
+          tester.respond(200, { name: sessionId.kernel.name,
+                                  id: sessionId.kernel.id });
         }
       });
       tester.initialStatus = 'dead';
@@ -230,12 +230,13 @@ describe('jupyter.services - session', () => {
         if (request.method === 'POST') {
           tester.respond(201, sessionId);
         } else {
-          tester.respond(200, [data]);
+          tester.respond(200, data);
         }
       });
       let options = createSessionOptions(sessionId);
       let sessionPromise = startNewSession(options);
-      expectFailure(sessionPromise, done, 'Invalid kernel id');
+      let msg = `Session failed to start: No running kernel with id: ${sessionId.kernel.id}`
+      expectFailure(sessionPromise, done, msg);
     });
 
     it('should fail if the kernel is not running', (done) => {
@@ -244,7 +245,7 @@ describe('jupyter.services - session', () => {
         if (request.method === 'POST') {
           tester.respond(201, sessionId);
         } else {
-          tester.respond(200, []);
+          tester.respond(400, {});
         }
       });
       let options = createSessionOptions(sessionId);
@@ -270,10 +271,10 @@ describe('jupyter.services - session', () => {
       let sessionId = createSessionId();
       let tester = new KernelTester(request => {
         if (request.url.indexOf('session') !== -1) {
-          tester.respond(200, [sessionId]);
+          tester.respond(200, sessionId);
         } else {
-          tester.respond(200, [ { name: sessionId.kernel.name,
-                                id: sessionId.kernel.id }]);
+          tester.respond(200, { name: sessionId.kernel.name,
+                                id: sessionId.kernel.id });
         }
       });
       let options = createSessionOptions(sessionId);
@@ -287,10 +288,10 @@ describe('jupyter.services - session', () => {
       let sessionId = createSessionId();
       let tester = new KernelTester(request => {
         if (request.url.indexOf('session') !== -1) {
-          tester.respond(200, [sessionId]);
+          tester.respond(200, sessionId);
         } else {
-          tester.respond(200, [ { name: sessionId.kernel.name,
-                                id: sessionId.kernel.id }]);
+          tester.respond(200, { name: sessionId.kernel.name,
+                                id: sessionId.kernel.id });
         }
       });
       let options = createSessionOptions(sessionId);
@@ -301,16 +302,9 @@ describe('jupyter.services - session', () => {
       });
     });
 
-    it('should fail if not given session options', (done) => {
-      let tester = new KernelTester();
-      let sessionId = createSessionId();
-      let sessionPromise = connectToSession(sessionId.id);
-      expectFailure(sessionPromise, done, 'Please specify session options');
-    });
-
     it('should fail if session is not available', (done) => {
       let tester = new KernelTester(() => {
-        tester.respond(200, []);
+        tester.respond(500, {});
       });
       let sessionId = createSessionId();
       let options = createSessionOptions(sessionId);
@@ -353,8 +347,8 @@ describe('jupyter.services - session', () => {
             if (request.method === 'PATCH') {
               tester.respond(200, id);
             } else {
-              tester.respond(200, [ { name: id.kernel.name,
-                                      id: id.kernel.id }]);
+              tester.respond(200, { name: id.kernel.name,
+                                      id: id.kernel.id });
             }
           }
           session.kernelChanged.connect((s, kernel) => {
@@ -577,8 +571,8 @@ describe('jupyter.services - session', () => {
             if (request.method === 'PATCH') {
               tester.respond(200, id);
             } else {
-              tester.respond(200, [ { name: id.kernel.name,
-                                      id: id.kernel.id }]);
+              tester.respond(200, { name: id.kernel.name,
+                                      id: id.kernel.id });
             }
           }
           session.changeKernel({ name: newName }).then(kernel => {
@@ -602,8 +596,8 @@ describe('jupyter.services - session', () => {
             if (request.method === 'PATCH') {
               tester.respond(200, id);
             } else {
-              tester.respond(200, [ { name: id.kernel.name,
-                                      id: id.kernel.id }]);
+              tester.respond(200, { name: id.kernel.name,
+                                      id: id.kernel.id });
             }
           }
           session.changeKernel({ id: newId }).then(kernel => {
@@ -753,8 +747,8 @@ describe('jupyter.services - session', () => {
           if (request.method === 'POST') {
             tester.respond(201, id)
           } else {
-            tester.respond(200, [ { name: id.kernel.name,
-                                    id: id.kernel.id }]);
+            tester.respond(200, { name: id.kernel.name,
+                                    id: id.kernel.id });
           }
         }
         manager.startNew({ notebookPath: 'test.ipynb'}).then(session => {
@@ -775,8 +769,8 @@ describe('jupyter.services - session', () => {
           if (request.method === 'POST') {
             tester.respond(201, id)
           } else {
-            tester.respond(200, [ { name: id.kernel.name,
-                                    id: id.kernel.id }]);
+            tester.respond(200, { name: id.kernel.name,
+                                    id: id.kernel.id });
           }
         }
         manager.startNew({ notebookPath: 'test.ipynb' }
@@ -804,8 +798,8 @@ function startSession(sessionId: ISessionId, tester?: KernelTester): Promise<INo
     if (request.method === 'POST') {
       tester.respond(201, sessionId);
     } else {
-      tester.respond(200, [ { name: sessionId.kernel.name,
-                              id: sessionId.kernel.id }]);
+      tester.respond(200, { name: sessionId.kernel.name,
+                              id: sessionId.kernel.id });
     }
   }
   let options = createSessionOptions(sessionId);

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -18,7 +18,7 @@ import {
 
 import {
   NotebookSessionManager, connectToSession, listRunningSessions,
-  startNewSession
+  startNewSession, findSessionById, findSessionByPath
 } from '../../lib/session';
 
 import {
@@ -258,6 +258,37 @@ describe('jupyter.services - session', () => {
       let sessionPromise = startNewSession(options);
       expectFailure(sessionPromise, done, 'Session failed to start');
     });
+  });
+
+  describe('findSessionByPath()', () => {
+
+    it('should find an existing session by path', (done) => {
+      let sessionId = createSessionId();
+      let tester = new KernelTester(request => {
+        tester.respond(200, [sessionId]);
+      });
+      debugger;
+      findSessionByPath(sessionId.notebook.path).then(newId => {
+        expect(newId.notebook.path).to.be(sessionId.notebook.path);
+        done();
+      });
+    });
+
+  });
+
+  describe('findSessionById()', () => {
+
+    it('should find an existing session by id', (done) => {
+      let sessionId = createSessionId();
+      let tester = new KernelTester(request => {
+        tester.respond(200, sessionId);
+      });
+      findSessionById(sessionId.id).then(newId => {
+        expect(newId.id).to.be(sessionId.id);
+        done();
+      });
+    });
+
   });
 
   describe('connectToSession()', () => {

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -26,10 +26,10 @@ import {
 } from '../../lib/isession';
 
 import {
-  deserialize, serialize 
+  deserialize, serialize
 } from '../../lib/serialize';
 
-import { 
+import {
   RequestHandler, ajaxSettings, expectFailure, doLater, KernelTester,
   createKernel
 } from './utils';
@@ -201,9 +201,9 @@ describe('jupyter.services - session', () => {
       tester.initialStatus = 'dead';
       let sessionId = createSessionId();
       let options = createSessionOptions(sessionId);
-      startNewSession(options).then(session => { 
+      startNewSession(options).then(session => {
         session.dispose();
-        done(); 
+        done();
       });
     });
 


### PR DESCRIPTION
Fixes #117.

- Adds new functions and methods to look for existing sessions and kernels
- Loosens the requirement to always pass options to some existing methods
- Cleans up the implementation of `connectTo` to use a targeted REST call
- Cleans up integration tests.