### PR TITLE
Make each instance of a kernel and a session unique and add iopub signal

### DIFF
--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -613,6 +613,11 @@ interface IKernel extends IDisposable {
   statusChanged: ISignal<IKernel, KernelStatus>;
 
   /**
+   * A signal emitted for iopub kernel messages.
+   */
+  iopubMessage: ISignal<IKernel, IKernelMessage>;
+
+  /**
    * A signal emitted for unhandled kernel message.
    */
   unhandledMessage: ISignal<IKernel, IKernelMessage>;

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -153,6 +153,11 @@ interface INotebookSession extends IDisposable {
   statusChanged: ISignal<INotebookSession, KernelStatus>;
 
   /**
+   * A signal emitted for iopub kernel messages.
+   */
+  iopubMessage: ISignal<INotebookSession, IKernelMessage>;
+
+  /**
    * A signal emitted for unhandled kernel message.
    */
   unhandledMessage: ISignal<INotebookSession, IKernelMessage>;

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -134,8 +134,8 @@ class KernelManager implements IKernelManager {
  * Find a kernel by id.
  *
  * #### Notes
- * If the kernel was already started via `startNewKernel`, the existing
- * IKernel object is used as the fulfillment value.
+ * If the kernel was already started via `startNewKernel`, we return its
+ * `IKernelId`.
  *
  * Otherwise, if `options` are given, we attempt to find to the existing
  * kernel.
@@ -145,9 +145,9 @@ class KernelManager implements IKernelManager {
 export
 function findKernelById(id: string, options?: IKernelOptions): Promise<IKernelId> {
   let kernels = Private.runningKernels;
-  for (let kernelId in kernels) {
-    let kernel = kernels[kernelId];
-    if (kernelId === id) {
+  for (let clientId in kernels) {
+    let kernel = kernels[clientId];
+    if (kernel.id === id) {
       let result = { id: kernel.id, name: kernel.name };
       return Promise.resolve(result);
     }
@@ -271,7 +271,7 @@ function startNewKernel(options?: IKernelOptions): Promise<IKernel> {
  *
  * #### Notes
  * If the kernel was already started via `startNewKernel`, the existing
- * Kernel object is used as the fulfillment value.
+ * Kernel object info is used to create another instance.
  *
  * Otherwise, if `options` are given, we attempt to connect to the existing
  * kernel found by calling `listRunningKernels`.
@@ -283,9 +283,11 @@ function startNewKernel(options?: IKernelOptions): Promise<IKernel> {
  */
 export
 function connectToKernel(id: string, options?: IKernelOptions): Promise<IKernel> {
-  let kernel = Private.runningKernels[id];
-  if (kernel) {
-    return Promise.resolve(kernel);
+  for (let clientId in Private.runningKernels) {
+    let kernel = Private.runningKernels[clientId];
+    if (kernel.id === id) {
+      return Promise.resolve(kernel.clone());
+    }
   }
   return Private.getKernelId(id, options).then(kernelId => {
     return new Kernel(options, id);
@@ -336,7 +338,7 @@ class Kernel implements IKernel {
     this._commPromises = new Map<string, Promise<IComm>>();
     this._comms = new Map<string, IComm>();
     this._createSocket();
-    Private.runningKernels[this._id] = this;
+    Private.runningKernels[this._clientId] = this;
   }
 
   /**
@@ -427,6 +429,20 @@ class Kernel implements IKernel {
   }
 
   /**
+   * Clone the current kernel with a new clientId.
+   */
+  clone(): IKernel {
+    let options = {
+      baseUrl: this._baseUrl,
+      wsUrl: this._wsUrl,
+      name: this._name,
+      username: this._username,
+      ajaxSettings: this.ajaxSettings
+    }
+    return new Kernel(options, this._id);
+  }
+
+  /**
    * Dispose of the resources held by the kernel.
    */
   dispose(): void {
@@ -450,7 +466,7 @@ class Kernel implements IKernel {
     this._status = KernelStatus.Dead;
     this._targetRegistry = null;
     clearSignalData(this);
-    delete Private.runningKernels[this._id];
+    delete Private.runningKernels[this._clientId];
   }
 
   /**
@@ -1114,7 +1130,7 @@ namespace Private {
    * A module private store for running kernels.
    */
   export
-  const runningKernels: { [key: string]: IKernel; } = Object.create(null);
+  const runningKernels: { [key: string]: Kernel; } = Object.create(null);
 
   /**
    * Restart a kernel.

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -61,6 +61,13 @@ class MockKernel implements IKernel {
   }
 
   /**
+   * A signal emitted for iopub kernel messages.
+   */
+  get iopubMessage(): ISignal<IKernel, IKernelMessage> {
+    return Private.iopubMessageSignal.bind(this);
+  }
+
+  /**
    * A signal emitted for unhandled kernel message.
    */
   get unhandledMessage(): ISignal<IKernel, IKernelMessage> {
@@ -290,6 +297,12 @@ namespace Private {
    */
   export
   const statusChangedSignal = new Signal<IKernel, KernelStatus>();
+
+  /**
+   * A signal emitted for iopub kernel messages.
+   */
+  export
+  const iopubMessageSignal = new Signal<IKernel, IKernelMessage>();
 
   /**
    * A signal emitted for unhandled kernel message.

--- a/src/mocksession.ts
+++ b/src/mocksession.ts
@@ -58,6 +58,13 @@ class MockSession implements INotebookSession {
   }
 
   /**
+   * A signal emitted for a kernel messages.
+   */
+  get iopubMessage(): ISignal<INotebookSession, IKernelMessage> {
+    return Private.iopubMessageSignal.bind(this);
+  }
+
+  /**
    * A signal emitted for an unhandled kernel message.
    */
   get unhandledMessage(): ISignal<INotebookSession, IKernelMessage> {
@@ -163,6 +170,12 @@ namespace Private {
    */
   export
   const statusChangedSignal = new Signal<INotebookSession, KernelStatus>();
+
+  /**
+   * A signal emitted for iopub kernel messages.
+   */
+  export
+  const iopubMessageSignal = new Signal<INotebookSession, IKernelMessage>();
 
   /**
    * A signal emitted for an unhandled kernel message.

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -56,8 +56,11 @@ describe('jupyter.services - Integration', () => {
         // should grab the same kernel object
         connectToKernel(kernel.id).then((kernel2) => {
           console.log('Should have gotten the same kernel');
-          if (kernel2.clientId !== kernel.clientId) {
-            throw Error('Did not reuse kernel');
+          if (kernel2.clientId === kernel.clientId) {
+            throw Error('Did create new kernel');
+          }
+          if (kernel2.id !== kernel.id) {
+            throw Error('Did clone kernel');
           }
           listRunningKernels().then((kernels) => {
             if (!kernels.length) {
@@ -120,8 +123,11 @@ describe('jupyter.services - Integration', () => {
           // should grab the same session object
           connectToSession(session.id, options).then((session2) => {
             console.log('Should have gotten the same kernel');
-            if (session2.kernel.clientId !== session.kernel.clientId) {
-              throw Error('Did not reuse session');
+            if (session2.kernel.clientId === session.kernel.clientId) {
+              throw Error('Did not clone the session');
+            }
+            if (session2.kernel.id !== session.kernel.id) {
+              throw Error('Did not clone the session');
             }
 
             listRunningSessions().then((sessions) => {

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -306,8 +306,9 @@ describe('jupyter.services - kernel', () => {
           let msg = createKernelMessage({
             msgType: 'foo',
             channel: 'bar',
-            session: 'baz'
+            session: kernel.clientId
           });
+          msg.parent_header = msg.header;
           tester.send(msg);
         });
       });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -294,6 +294,48 @@ describe('jupyter.services - kernel', () => {
       });
     });
 
+    context('#iopubMessage', () => {
+
+      it('should be emitted for an iopub message', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          kernel.iopubMessage.connect((k, msg) => {
+            expect(msg.header.msg_type).to.be('status');
+            kernel.dispose();
+            done();
+          });
+          let msg = createKernelMessage({
+            msgType: 'status',
+            channel: 'iopub',
+            session: kernel.clientId
+          });
+          msg.content.execution_state = 'idle';
+          msg.parent_header = msg.header;
+          tester.send(msg);
+        });
+      });
+
+      it('should be emitted regardless of the sender', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          kernel.iopubMessage.connect((k, msg) => {
+            expect(msg.header.msg_type).to.be('status');
+            kernel.dispose();
+            done();
+          });
+          let msg = createKernelMessage({
+            msgType: 'status',
+            channel: 'iopub',
+            session: 'baz'
+          });
+          msg.content.execution_state = 'idle';
+          msg.parent_header = msg.header;
+          tester.send(msg);
+        });
+      });
+
+    });
+
     context('#unhandledMessage', () => {
 
       it('should be emitted for an unhandled message', (done) => {
@@ -312,6 +354,46 @@ describe('jupyter.services - kernel', () => {
           tester.send(msg);
         });
       });
+
+      it('should not be emitted for an iopub signal', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let called = false;
+          kernel.unhandledMessage.connect((k, msg) => {
+            called = true;
+          });
+          let msg = createKernelMessage({
+            msgType: 'status',
+            channel: 'iopub',
+            session: kernel.clientId
+          });
+          msg.content.execution_state = 'idle';
+          msg.parent_header = msg.header;
+          tester.send(msg);
+          expect(called).to.be(false);
+          done();
+        });
+      });
+
+      it('should not be emitted for a different client session', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let called = false;
+          kernel.unhandledMessage.connect((k, msg) => {
+            called = true;
+          });
+          let msg = createKernelMessage({
+            msgType: 'foo',
+            channel: 'bar',
+            session: 'baz'
+          });
+          msg.parent_header = msg.header;
+          tester.send(msg);
+          expect(called).to.be(false);
+          done();
+        });
+      });
+
     });
 
     context('#id', () => {

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -1223,6 +1223,7 @@ describe('jupyter.services - kernel', () => {
           manager.connectTo(id).then(newKernel => {
             expect(newKernel.name).to.be(kernel.name);
             expect(newKernel.id).to.be(kernel.id);
+            expect(newKernel).to.not.be(kernel);
             done();
           });
         });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -437,8 +437,9 @@ describe('jupyter.services - session', () => {
           let msg = createKernelMessage({
             msgType: 'foo',
             channel: 'bar',
-            session: 'baz'
+            session: session.kernel.clientId
           });
+          msg.parent_header = msg.header;
           tester.send(msg);
         });
       });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -298,6 +298,9 @@ describe('jupyter.services - session', () => {
       startSession(sessionId).then(session => {
         connectToSession(sessionId.id).then((newSession) => {
           expect(newSession.id).to.be(sessionId.id);
+          expect(newSession.kernel.id).to.be(sessionId.kernel.id);
+          expect(newSession).to.not.be(session);
+          expect(newSession.kernel).to.not.be(session.kernel);
           session.dispose();
           done();
         });
@@ -902,7 +905,10 @@ describe('jupyter.services - session', () => {
         manager.startNew({ notebookPath: 'test.ipynb' }
         ).then(session => {
           manager.connectTo(session.id).then(newSession => {
-            expect(newSession).to.be(session);
+            expect(newSession.id).to.be(session.id);
+            expect(newSession.kernel.id).to.be(session.kernel.id);
+            expect(newSession).to.not.be(session);
+            expect(newSession.kernel).to.not.be(session.kernel);
             session.dispose();
             done();
           });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -423,6 +423,29 @@ describe('jupyter.services - session', () => {
       });
     });
 
+    context('#iopubMessage', () => {
+
+      it('should be emitted for an iopub message', (done) => {
+        let tester = new KernelTester();
+        let sessionId = createSessionId();
+        startSession(sessionId, tester).then(session => {
+          session.iopubMessage.connect((s, msg) => {
+            expect(msg.header.msg_type).to.be('status');
+            session.dispose();
+            done();
+          });
+          let msg = createKernelMessage({
+            msgType: 'status',
+            channel: 'iopub',
+            session: ''
+          });
+          msg.content.execution_state = 'idle';
+          msg.parent_header = msg.header;
+          tester.send(msg);
+        });
+      });
+    });
+
     context('#unhandledMessage', () => {
 
       it('should be emitted for an unhandled message', (done) => {


### PR DESCRIPTION
This allows multiple client connections to connect to a given session or kernel with a unique client session id, since the server side websockets are one-to-one for client session ids.

Also adds an iopub signal, and only using the unhandledmessage signal for messages that are not iopub and match the current client session id.

cf https://github.com/jupyter/jupyter-js-notebook/issues/166#issuecomment-215853776