### PR TITLE
Use updates from server

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepublish": "npm run build",
     "test:coverage": "istanbul cover --dir test/coverage _mocha -- test/build/test*.js",
     "test:integration": "cd test && python integration_test.py",
-    "test:debug": "mocha test/build/testsession.js --debug-brk",
-    "test": "mocha test/build/testsession.js"
+    "test:debug": "mocha test/build/test*.js --debug-brk",
+    "test": "mocha test/build/test*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepublish": "npm run build",
     "test:coverage": "istanbul cover --dir test/coverage _mocha -- test/build/test*.js",
     "test:integration": "cd test && python integration_test.py",
-    "test:debug": "mocha test/build/test*.js --debug-brk",
-    "test": "mocha test/build/test*.js"
+    "test:debug": "mocha test/build/testsession.js --debug-brk",
+    "test": "mocha test/build/testsession.js"
   },
   "repository": {
     "type": "git",

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -224,6 +224,11 @@ interface INotebookSession extends IDisposable {
   changeKernel(options: IKernelId): Promise<IKernel>;
 
   /**
+   * Update the session based on a session model from the server.
+   */
+  update(id: ISessionId): void;
+
+  /**
    * Kill the kernel and shutdown the session.
    *
    * #### Notes

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -153,6 +153,11 @@ interface INotebookSession extends IDisposable {
   statusChanged: ISignal<INotebookSession, KernelStatus>;
 
   /**
+   * A signal emitted when the notebook path changes.
+   */
+  notebookPathChanged: ISignal<INotebookSession, string>;
+
+  /**
    * A signal emitted for iopub kernel messages.
    */
   iopubMessage: ISignal<INotebookSession, IKernelMessage>;

--- a/src/isession.ts
+++ b/src/isession.ts
@@ -224,11 +224,6 @@ interface INotebookSession extends IDisposable {
   changeKernel(options: IKernelId): Promise<IKernel>;
 
   /**
-   * Update the session based on a session model from the server.
-   */
-  update(id: ISessionId): void;
-
-  /**
    * Kill the kernel and shutdown the session.
    *
    * #### Notes

--- a/src/mocksession.ts
+++ b/src/mocksession.ts
@@ -72,6 +72,13 @@ class MockSession implements INotebookSession {
   }
 
   /**
+   * A signal emitted when the notebook path changes.
+   */
+  get notebookPathChanged(): ISignal<INotebookSession, string> {
+    return Private.notebookPathChangedSignal.bind(this);
+  }
+
+  /**
    * Get the session kernel object.
    */
   get kernel(): IKernel {
@@ -182,4 +189,11 @@ namespace Private {
    */
   export
   const unhandledMessageSignal = new Signal<INotebookSession, IKernelMessage>();
+
+  /**
+   * A signal emitted when the notebook path changes.
+   */
+  export
+  const notebookPathChangedSignal = new Signal<INotebookSession, string>();
+
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -340,6 +340,13 @@ class NotebookSession implements INotebookSession {
   }
 
   /**
+   * A signal emitted when the notebook path changes.
+   */
+  get notebookPathChanged(): ISignal<INotebookSession, string> {
+    return Private.notebookPathChangedSignal.bind(this);
+  }
+
+  /**
    * Get the session id.
    *
    * #### Notes
@@ -425,6 +432,9 @@ class NotebookSession implements INotebookSession {
     if (this._updating) {
       return Promise.resolve(void 0);
     }
+    if (this._notebookPath !== id.notebook.path) {
+      this.notebookPathChanged.emit(id.notebook.path);
+    }
     this._notebookPath = id.notebook.path;
     let options = this._getKernelOptions();
     if (id.kernel.id !== this._kernel.id) {
@@ -470,9 +480,7 @@ class NotebookSession implements INotebookSession {
     let data = JSON.stringify({
       notebook: { path }
     });
-    return this._patch(data).then(id => {
-      this._notebookPath = id.notebook.path;
-    });
+    return this._patch(data).then(() => { return void 0; });
   }
 
   /**
@@ -641,6 +649,12 @@ namespace Private {
    */
   export
   const unhandledMessageSignal = new Signal<INotebookSession, IKernelMessage>();
+
+  /**
+   * A signal emitted when the notebook path changes.
+   */
+  export
+  const notebookPathChangedSignal = new Signal<INotebookSession, string>();
 
   /**
    * The running sessions.

--- a/src/session.ts
+++ b/src/session.ts
@@ -436,16 +436,10 @@ class NotebookSession implements INotebookSession {
       this.notebookPathChanged.emit(id.notebook.path);
     }
     this._notebookPath = id.notebook.path;
-    let options = this._getKernelOptions();
     if (id.kernel.id !== this._kernel.id) {
+      let options = this._getKernelOptions();
       options.name = id.kernel.name;
       return connectToKernel(id.kernel.id, options).then(kernel => {
-        this.setupKernel(kernel);
-        this.kernelChanged.emit(kernel);
-      });
-    } else if (id.kernel.name !== this._kernel.name) {
-      options.name = id.kernel.name;
-      return startNewKernel(options).then(kernel => {
         this.setupKernel(kernel);
         this.kernelChanged.emit(kernel);
       });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -494,6 +494,28 @@ describe('jupyter.services - session', () => {
       });
     });
 
+    context('#notebookPathChanged', () => {
+
+      it('should be emitted when the notebook path changes', (done) => {
+        let tester = new KernelTester();
+        let id = createSessionId();
+        let newPath = '/foo.ipynb';
+        let newId = JSON.parse(JSON.stringify(id));
+        newId.notebook.path = newPath;
+        startSession(id, tester).then(session => {
+          tester.onRequest = () => {
+            tester.respond(200, newId);
+          };
+          session.notebookPathChanged.connect((s, path) => {
+            expect(path).to.be(newPath);
+            done();
+          });
+          session.renameNotebook(newPath);
+        });
+      });
+
+    });
+
     context('#id', () => {
 
       it('should be a read only string', (done) => {


### PR DESCRIPTION
When fetching session information from the server, update existing client side instances.
Also adds a `notebookPathChanged` signal on the session.
The intent is that one part of the application will call `listSessions` periodically, which will update the information of all running sessions.

cf https://github.com/jupyter/jupyter-js-notebook/issues/166#issuecomment-215853776