### PR TITLE
Make kernel spec and info handling part of MockKernel

### DIFF
--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -368,7 +368,7 @@ namespace IKernel {
     /**
      * The original outgoing message.
      */
-    msg: KernelMessage.IMessage;
+    msg: KernelMessage.IShellMessage;
 
     /**
      * Test whether the future is done.

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -1273,9 +1273,11 @@ class Comm extends DisposableDelegate implements IKernel.IComm {
     };
     let msg = createShellMessage(options, content, metadata);
     let future = this._kernel.sendShellMessage(msg, false, true);
+    options.channel = 'iopub';
+    let ioMsg = createKernelMessage(options, content, metadata);
     let onClose = this._onClose;
     if (onClose) {
-      onClose(future.msg as KernelMessage.ICommCloseMsg);
+      onClose(ioMsg as KernelMessage.ICommCloseMsg);
     }
     this.dispose();
     return future;

--- a/src/kernelfuture.ts
+++ b/src/kernelfuture.ts
@@ -19,7 +19,7 @@ class KernelFutureHandler extends DisposableDelegate implements IKernel.IFuture 
   /**
    * Construct a new KernelFutureHandler.
    */
-  constructor(cb: () => void, msg: KernelMessage.IMessage, expectShell: boolean, disposeOnDone: boolean) {
+  constructor(cb: () => void, msg: KernelMessage.IShellMessage, expectShell: boolean, disposeOnDone: boolean) {
     super(cb);
     this._msg = msg;
     if (!expectShell) {
@@ -31,7 +31,7 @@ class KernelFutureHandler extends DisposableDelegate implements IKernel.IFuture 
   /**
    * Get the original outgoing message.
    */
-  get msg(): KernelMessage.IMessage {
+  get msg(): KernelMessage.IShellMessage {
     return this._msg;
   }
 
@@ -180,7 +180,7 @@ class KernelFutureHandler extends DisposableDelegate implements IKernel.IFuture 
     this._status |= flag;
   }
 
-  private _msg: KernelMessage.IMessage = null;
+  private _msg: KernelMessage.IShellMessage = null;
   private _status = 0;
   private _stdin: (msg: KernelMessage.IStdinMessage) => void = null;
   private _iopub: (msg: KernelMessage.IIOPubMessage) => void = null;

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -307,8 +307,9 @@ class MockKernel implements IKernel {
       });
       this.sendServerMessage('execute_reply', 'shell', {
         execution_count: ++this._executionCount,
-        data: {},
-        metadata: {}
+        status: 'ok',
+        user_expressions: {},
+        payload: {}
       });
     });
     return future;

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -98,8 +98,10 @@ class MockKernel implements IKernel {
   username = '';
   clientId = '';
 
-  constructor(options?: IKernel.IModel) {
-    options = options || {};
+  /**
+   * Construct a new mock kernel.
+   */
+  constructor(options: IKernel.IModel = {}) {
     this.id = options.id || '';
     this.name = options.name || 'python';
     let name = this.name;
@@ -234,7 +236,7 @@ class MockKernel implements IKernel {
   }
 
   /**
-   * Send a `kernel_info_request` message.
+   * Get the kernel info.
    */
   kernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
     let options: KernelMessage.IOptions = {

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -31,6 +31,62 @@ import {
 
 
 /**
+ * The default kernel spec models.
+ */
+export
+const KERNELSPECS: IKernel.ISpecModels = {
+  default: 'python',
+  kernelspecs: {
+    python: {
+      name: 'python',
+      spec: {
+        language: 'python',
+        argv: [],
+        display_name: 'Python',
+        env: {}
+      },
+      resources: {}
+    },
+    shell: {
+      name: 'shell',
+      spec: {
+        language: 'shell',
+        argv: [],
+        display_name: 'Shell',
+        env: {}
+      },
+      resources: {}
+    }
+  }
+};
+
+
+/**
+ * The default language infos.
+ */
+const LANGUAGE_INFOS: { [key: string]: KernelMessage.ILanguageInfo } = {
+  python: {
+    name: 'python',
+    version: '1',
+    mimetype: 'text/x-python',
+    file_extension: '.py',
+    pygments_lexer: 'python',
+    codemirror_mode: 'python',
+    nbconverter_exporter: ''
+  },
+  shell: {
+    name: 'shell',
+    version: '1',
+    mimetype: 'text/x-sh',
+    file_extension: '.sh',
+    pygments_lexer: 'shell',
+    codemirror_mode: 'shell',
+    nbconverter_exporter: ''
+  }
+};
+
+
+/**
  * A mock kernel object.
  * It only keeps one kernel future at a time.
  */
@@ -46,6 +102,19 @@ class MockKernel implements IKernel {
     options = options || {};
     this.id = options.id || '';
     this.name = options.name || 'python';
+    let name = this.name;
+    if (!(name in KERNELSPECS.kernelspecs)) {
+      name = 'python';
+    }
+    this._kernelspec = KERNELSPECS.kernelspecs[name].spec;
+    this._kernelInfo = {
+      protocol_version: '1',
+      implementation: 'foo',
+      implementation_version: '1',
+      language_info: LANGUAGE_INFOS[name],
+      banner: 'Hello',
+      help_links: {}
+    };
     Promise.resolve().then(() => {
       this._changeStatus('idle');
     });
@@ -179,13 +248,6 @@ class MockKernel implements IKernel {
   }
 
   /**
-   * Set the kernel info for the mock kernel.
-   */
-  setKernelInfo(value: KernelMessage.IInfoReply): void {
-    this._kernelInfo = value;
-  }
-
-  /**
    * Send a `complete_request` message.
    */
   complete(content: KernelMessage.ICompleteRequest): Promise<KernelMessage.ICompleteReplyMsg> {
@@ -288,13 +350,6 @@ class MockKernel implements IKernel {
    */
   getKernelSpec(): Promise<IKernel.ISpec> {
     return Promise.resolve(this._kernelspec);
-  }
-
-  /**
-   * Set the kernel spec associated with the kernel.
-   */
-  setKernelSpec(value: IKernel.ISpec): void {
-    this._kernelspec = value;
   }
 
   private _sendKernelMessage(msgType: string, channel: KernelMessage.Channel, content: JSONObject): Promise<KernelMessage.IShellMessage> {

--- a/test/src/testmockkernel.ts
+++ b/test/src/testmockkernel.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+'use strict';
+
+import expect = require('expect.js');
+
+import {
+  KernelMessage
+} from '../../lib/ikernel';
+
+import {
+  MockKernel
+} from '../../lib/mockkernel';
+
+
+describe('mockkernel', () => {
+
+  describe('MockKernel', () => {
+
+    describe('#constructor()', () => {
+
+      it('should accept no arguments', () => {
+        let kernel = new MockKernel();
+        expect(kernel).to.be.a(MockKernel);
+      });
+
+      it('should accept a kernel model', () => {
+        let kernel = new MockKernel({ name: 'shell' });
+        expect(kernel.name).to.be('shell');
+      });
+
+    });
+
+    describe('#interrupt()', () => {
+
+      it('should change the status to busy then idle', (done) => {
+        let kernel = new MockKernel();
+        kernel.interrupt().then(() => {
+          expect(kernel.status).to.be('idle');
+          done();
+        });
+        expect(kernel.status).to.be('busy');
+      });
+
+    });
+
+    describe('#restart()', () => {
+
+      it('should change the status to restarting then idle', (done) => {
+        let kernel = new MockKernel();
+        kernel.restart().then(() => {
+          expect(kernel.status).to.be('idle');
+          done();
+        });
+        expect(kernel.status).to.be('restarting');
+      });
+
+    });
+
+    describe('#kernelInfo()', () => {
+
+      it('should get the kernel info for the mock kernel', (done) => {
+        let kernel = new MockKernel();
+        expect(kernel.name).to.be('python');
+        kernel.kernelInfo().then(reply => {
+          expect(reply.content.language_info.name).to.be('python');
+          done();
+        });
+      });
+
+    });
+
+    describe('#execute()', () => {
+
+      it('should execute the code on the mock kernel', (done) => {
+        let kernel = new MockKernel();
+        let future = kernel.execute({ code: 'a = 1'});
+        future.onDone = () => { done(); };
+      });
+
+      it('should emit one iopub stream message', (done) => {
+        let kernel = new MockKernel();
+        let future = kernel.execute({ code: 'a = 1'});
+        let called = 0;
+        future.onIOPub = (msg) => {
+          if (msg.header.msg_type !== 'status') {
+            called++;
+          }
+        };
+        future.onDone = () => {
+          expect(called).to.be(1);
+          done();
+        };
+      });
+
+      it('should increment the execution count', (done) => {
+        let kernel = new MockKernel();
+        let future = kernel.execute({ code: 'a = 1' });
+        future.onReply = (reply: KernelMessage.IExecuteReplyMsg)  => {
+          expect(reply.content.execution_count).to.be(1);
+        };
+        future.onDone = () => {
+          future = kernel.execute({ code: 'a = 1' });
+          future.onReply = (reply: KernelMessage.IExecuteReplyMsg) => {
+            expect(reply.content.execution_count).to.be(2);
+            done();
+          };
+        };
+      });
+
+    });
+
+    describe('#getKernelSpec()', () => {
+
+      it('should get the kernel spec for the mock kernel', (done) => {
+        let kernel = new MockKernel({ name: 'shell' });
+        expect(kernel.name).to.be('shell');
+        kernel.getKernelSpec().then(spec => {
+          expect(spec.display_name).to.be('Shell');
+          done();
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/testmockkernel.ts
+++ b/test/src/testmockkernel.ts
@@ -75,7 +75,7 @@ describe('mockkernel', () => {
       it('should execute the code on the mock kernel', (done) => {
         let kernel = new MockKernel();
         let future = kernel.execute({ code: 'a = 1'});
-        future.onReply = (reply: any) => {
+        future.onReply = (reply: KernelMessage.IExecuteOkReplyMsg) => {
           expect(reply.content.status).to.be('ok');
           done();
         };
@@ -130,11 +130,11 @@ describe('mockkernel', () => {
         let future0 = kernel.execute({ code: ERROR_INPUT, stop_on_error: true });
         let future1 = kernel.execute({ code: 'b = 2' });
         let called = false;
-        future0.onReply = (reply: any) => {
+        future0.onReply = (reply: KernelMessage.IExecuteErrorReplyMsg) => {
           expect(reply.content.status).to.be('error');
           called = true;
         };
-        future1.onReply = (reply: any) => {
+        future1.onReply = (reply: KernelMessage.IExecuteErrorReplyMsg) => {
           expect(called).to.be(true);
           expect(reply.content.status).to.be('error');
           done();

--- a/test/src/testmockkernel.ts
+++ b/test/src/testmockkernel.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/ikernel';
 
 import {
-  MockKernel
+  MockKernel, ERROR_INPUT
 } from '../../lib/mockkernel';
 
 
@@ -75,7 +75,7 @@ describe('mockkernel', () => {
       it('should execute the code on the mock kernel', (done) => {
         let kernel = new MockKernel();
         let future = kernel.execute({ code: 'a = 1'});
-        future.onReply = (reply: KernelMessage.IExecuteOkReplyMsg) => {
+        future.onReply = (reply: any) => {
           expect(reply.content.status).to.be('ok');
           done();
         };
@@ -121,6 +121,22 @@ describe('mockkernel', () => {
         };
         future1.onDone = () => {
           expect(called).to.be(true);
+          done();
+        };
+      });
+
+      it('should error remaining executes if `stop_on_error` and an error occurs', (done) => {
+        let kernel = new MockKernel();
+        let future0 = kernel.execute({ code: ERROR_INPUT, stop_on_error: true });
+        let future1 = kernel.execute({ code: 'b = 2' });
+        let called = false;
+        future0.onReply = (reply: any) => {
+          expect(reply.content.status).to.be('error');
+          called = true;
+        };
+        future1.onReply = (reply: any) => {
+          expect(called).to.be(true);
+          expect(reply.content.status).to.be('error');
           done();
         };
       });

--- a/test/src/testmockkernel.ts
+++ b/test/src/testmockkernel.ts
@@ -75,7 +75,10 @@ describe('mockkernel', () => {
       it('should execute the code on the mock kernel', (done) => {
         let kernel = new MockKernel();
         let future = kernel.execute({ code: 'a = 1'});
-        future.onDone = () => { done(); };
+        future.onReply = (reply: KernelMessage.IExecuteOkReplyMsg) => {
+          expect(reply.content.status).to.be('ok');
+          done();
+        };
       });
 
       it('should emit one iopub stream message', (done) => {

--- a/test/src/testmockkernel.ts
+++ b/test/src/testmockkernel.ts
@@ -111,6 +111,21 @@ describe('mockkernel', () => {
         };
       });
 
+      it('should allow two executions in a row', (done) => {
+        let kernel = new MockKernel();
+        let future0 = kernel.execute({ code: 'a = 1' });
+        let future1 = kernel.execute({ code: 'b = 2' });
+        let called = false;
+        future0.onDone = () => {
+          called = true;
+        };
+        future1.onDone = () => {
+          expect(called).to.be(true);
+          done();
+        };
+      });
+
+
     });
 
     describe('#getKernelSpec()', () => {


### PR DESCRIPTION
Only the currently used methods are covered in the unit tests for now.