### PR TITLE
fix issue https://github.com/jupyter/jupyter-js-services/issues/151

### DIFF
--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -287,7 +287,7 @@ function connectToKernel(id: string, options?: IKernel.IOptions): Promise<IKerne
       return Promise.resolve(kernel.clone());
     }
   }
-  return Private.getKernelModel(id, options).then(model => {
+  return Private.getKernelModel(utils.urlJoinEncode(id), options).then(model => {
     return new Kernel(options, id);
   }).catch(() => {
     return Private.typedThrow<IKernel.IModel>(`No running kernel with id: ${id}`);


### PR DESCRIPTION
This change can fix connectToKernel issue to reconnect running kernel. I have run the unit tests and passes:
````
npm test

> jupyter-js-services@0.11.1 test /root/jupyter-js-services
> mocha test/build/test*.js



  jupyter.services - Comm
    Kernel
      #connectToComm()
Starting WebSocket: ws://localhost:8888/api/kernels/15193a534a0b5e6ccb6c43819ef6b3ef
        ✓ should create an instance of IComm
Kernel: starting (15193a534a0b5e6ccb6c43819ef6b3ef)
Starting WebSocket: ws://localhost:8888/api/kernels/5bfdd06a62339a7e48ca91c30b608a87
        ✓ should use the given commId
Kernel: starting (5bfdd06a62339a7e48ca91c30b608a87)
Starting WebSocket: ws://localhost:8888/api/kernels/ca9edee2da42a0398b0c4e241a3c91ac
        ✓ should create an instance of IComm
Kernel: starting (ca9edee2da42a0398b0c4e241a3c91ac)
Starting WebSocket: ws://localhost:8888/api/kernels/f278408f87d6bedc6d0ea4634bb99d1c
        ✓ should use the given commId
Kernel: starting (f278408f87d6bedc6d0ea4634bb99d1c)
Starting WebSocket: ws://localhost:8888/api/kernels/54628b2eb5b5a5322a4df41767bca451
        ✓ should reuse an existing comm
Kernel: starting (54628b2eb5b5a5322a4df41767bca451)
      #registerCommTarget()
Starting WebSocket: ws://localhost:8888/api/kernels/89abc5f7ba3ee79010006bc38743a79f
Kernel: starting (89abc5f7ba3ee79010006bc38743a79f)
        ✓ should call the provided callback
      #commInfo()
Starting WebSocket: ws://localhost:8888/api/kernels/edb235906c4d403965a4e9cf726f4caa
Kernel: starting (edb235906c4d403965a4e9cf726f4caa)
        ✓ should get the comm info
Starting WebSocket: ws://localhost:8888/api/kernels/949b5eccccfcdb8958d35fabe4771108
Kernel: starting (949b5eccccfcdb8958d35fabe4771108)
        ✓ should allow an optional target
      #isDisposed
Starting WebSocket: ws://localhost:8888/api/kernels/e61bc61efb3bf217c5674cf9da0c116b
        ✓ should be true after we dispose of the comm
Kernel: starting (e61bc61efb3bf217c5674cf9da0c116b)
Starting WebSocket: ws://localhost:8888/api/kernels/99ce551b5a1fa4a0869bd8994db192d5
        ✓ should be safe to call multiple times
Kernel: starting (99ce551b5a1fa4a0869bd8994db192d5)
      #dispose()
Starting WebSocket: ws://localhost:8888/api/kernels/b34d6b69fdc8f0565a4dbd5828e7fe57
        ✓ should dispose of the resources held by the comm
Kernel: starting (b34d6b69fdc8f0565a4dbd5828e7fe57)
      #_handleOpen()
Starting WebSocket: ws://localhost:8888/api/kernels/7afba2796e616072e018c4dee1070ddb
        ✓ should load a required module
Kernel: starting (7afba2796e616072e018c4dee1070ddb)
Starting WebSocket: ws://localhost:8888/api/kernels/0e34a1e589ff2db903eb66d7f4ad2c0d
        ✓ should fail to load the module
Kernel: starting (0e34a1e589ff2db903eb66d7f4ad2c0d)
Starting WebSocket: ws://localhost:8888/api/kernels/f8f22f6254bc503337c783da6ab6ff17
        ✓ should fail to find the target
Kernel: starting (f8f22f6254bc503337c783da6ab6ff17)
    IComm
      #commId
Starting WebSocket: ws://localhost:8888/api/kernels/d93d93f03683e57225701151e1bdf7a4
        ✓ should be a read only string
Kernel: starting (d93d93f03683e57225701151e1bdf7a4)
      #targetName
Starting WebSocket: ws://localhost:8888/api/kernels/009815bc3e3a19f4d0c3bb09fcf4d136
        ✓ should be a read only string
Kernel: starting (009815bc3e3a19f4d0c3bb09fcf4d136)
      #onClose
Starting WebSocket: ws://localhost:8888/api/kernels/9e0cd7b03981d7c4483bdf59b76ac065
        ✓ should be readable and writable function
Kernel: starting (9e0cd7b03981d7c4483bdf59b76ac065)
Starting WebSocket: ws://localhost:8888/api/kernels/b718085a4f6f5af30035ad10fa081089
Kernel: starting (b718085a4f6f5af30035ad10fa081089)
        ✓ should be called when the server side closes
Starting WebSocket: ws://localhost:8888/api/kernels/9f3cb71826c765221bd07c039a8094bf
        ✓ should ignore a close message for an unregistered id
Kernel: starting (9f3cb71826c765221bd07c039a8094bf)
Comm not found for comm id 1234
      #onMsg
Starting WebSocket: ws://localhost:8888/api/kernels/72c35942fa8eab0ccf1fe3144687e0e9
        ✓ should be readable and writable function
Kernel: starting (72c35942fa8eab0ccf1fe3144687e0e9)
Starting WebSocket: ws://localhost:8888/api/kernels/593f5c6e71df17977b2b29ff2d49e8d0
Kernel: starting (593f5c6e71df17977b2b29ff2d49e8d0)
        ✓ should be called when the server side sends a message
Starting WebSocket: ws://localhost:8888/api/kernels/c4b3b5a0fd4853d2603c46737bd58817
        ✓ should ignore a message for an unregistered id
Kernel: starting (c4b3b5a0fd4853d2603c46737bd58817)
Missing property 'data'
      #open()
Starting WebSocket: ws://localhost:8888/api/kernels/42640aa3c451ccb22a49b178341599f4
Kernel: starting (42640aa3c451ccb22a49b178341599f4)
        ✓ should send a message to the server
Starting WebSocket: ws://localhost:8888/api/kernels/79a644446e6191439b0e567fb8424463
Kernel: starting (79a644446e6191439b0e567fb8424463)
        ✓ should yield a future
      #send()
Starting WebSocket: ws://localhost:8888/api/kernels/3b38897770f19c81f1ee9283f0259f21
Kernel: starting (3b38897770f19c81f1ee9283f0259f21)
        ✓ should send a message to the server
Starting WebSocket: ws://localhost:8888/api/kernels/515da9724a3648054b7e1f09f5f6701b
Kernel: starting (515da9724a3648054b7e1f09f5f6701b)
        ✓ should yield a future
      #close()
Starting WebSocket: ws://localhost:8888/api/kernels/771a9b16b2c197b3ea6b0c9202264118
Kernel: starting (771a9b16b2c197b3ea6b0c9202264118)
        ✓ should send a message to the server
Starting WebSocket: ws://localhost:8888/api/kernels/b578cd18732ce7cd5f87dce9ed706965
        ✓ should trigger an onClose
Kernel: starting (b578cd18732ce7cd5f87dce9ed706965)
Starting WebSocket: ws://localhost:8888/api/kernels/5d4def1b6dee3cafbe2e2709e21b62a7
        ✓ should not send subsequent messages
Kernel: starting (5d4def1b6dee3cafbe2e2709e21b62a7)
Starting WebSocket: ws://localhost:8888/api/kernels/fe114703e99cd4b9604fb65019fc6e28
        ✓ should be a no-op if already closed
Kernel: starting (fe114703e99cd4b9604fb65019fc6e28)
Starting WebSocket: ws://localhost:8888/api/kernels/c1981991f488a99bf638d8e2be61aeb6
Kernel: starting (c1981991f488a99bf638d8e2be61aeb6)
        ✓ should yield a future
Comm not found for comm id 8a163873881f41d8773d69d3aa22dc6c

  jupyter.services - IConfigSection
    getConfigSection()
      ✓ should complete properly
      ✓ should accept ajaxOptions
      ✓ should load a config
      ✓ should fail for an incorrect response
    #update()
      ✓ should update a config
      ✓ should accept ajaxOptions
      ✓ should fail for an incorrect response

  jupyter.services - ConfigWithDefaults
    #constructor()
      ✓ should complete properly
    #get()
      ✓ should get a new config value
      ✓ should get a default config value
      ✓ should get a default config value with no class
    #set()
      ✓ should set a value in a class immediately
      ✓ should set a top level value
      ✓ should fail for an invalid response

  jupyter.services - Contents
    #constructor()
      ✓ should complete properly
    #get()
      ✓ should get a file
      ✓ should get a directory
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #newUntitled()
      ✓ should create a file
      ✓ should create a directory
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #delete()
      ✓ should delete a file
      ✓ should accept ajax options
      ✓ should fail for an incorrect response
      ✓ should throw a specific error
      ✓ should throw a general error
    #rename()
      ✓ should rename a file
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #save()
      ✓ should save a file
      ✓ should create a new file
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #copy()
      ✓ should copy a file
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #createCheckpoint()
      ✓ should create a checkpoint
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #listCheckpoints()
      ✓ should list the checkpoints
      ✓ should accept ajax options
      ✓ should fail for an incorrect model
      ✓ should fail for an incorrect response
    #restoreCheckpoint()
      ✓ should create a checkpoint
      ✓ should accept ajax options
      ✓ should fail for an incorrect response
    #deleteCheckpoint()
      ✓ should delete a checkpoint
      ✓ should accept ajax options
      ✓ should fail for an incorrect response
    #listContents()
      ✓ should get a directory
      ✓ should accept ajax options

  jupyter.services - kernel
    listRunningKernels()
      ✓ should yield a list of valid kernel ids
      ✓ should accept ajax options
      ✓ should throw an error for an invalid model
      ✓ should throw an error for an invalid response
API request failed (500 Internal Server Error):
      ✓ should throw an error for an error response
    startNewKernel()
Starting WebSocket: ws://localhost:8888/api/kernels/2ae9093b8940dafdef3c9cc437f125ea
      ✓ should create an IKernel object
Kernel: starting (2ae9093b8940dafdef3c9cc437f125ea)
Starting WebSocket: ws://localhost:8888/api/kernels/9ccc09a1eeb830f5cb92ff623ecddcc8
      ✓ should accept ajax options
Kernel: starting (9ccc09a1eeb830f5cb92ff623ecddcc8)
Starting WebSocket: ws://localhost:8888/api/kernels/41c31f713f84bb83f9c502154a81a7a5
Kernel: dead (41c31f713f84bb83f9c502154a81a7a5)
      ✓ should still start if the kernel dies
      ✓ should throw an error for an invalid kernel id
      ✓ should throw an error for another invalid kernel id
      ✓ should throw an error for an invalid response
API request failed (500 Internal Server Error):
      ✓ should throw an error for an error response
Starting WebSocket: ws://localhost:8888/api/kernels/40db911b5d5904f2bd6dc7290f8984f5
Kernel: starting (40db911b5d5904f2bd6dc7290f8984f5)
Kernel: reconnecting (40db911b5d5904f2bd6dc7290f8984f5)
      ✓ should auto-reconnect on websocket error
Connection lost, reconnecting in 1 seconds.
    findKernelById()
      ✓ should find an existing kernel by id
    connectToKernel()
Starting WebSocket: ws://localhost:8888/api/kernels/c37fca6b0e0180fb59592ffa33a25e52
Starting WebSocket: ws://localhost:8888/api/kernels/c37fca6b0e0180fb59592ffa33a25e52
Kernel: starting (c37fca6b0e0180fb59592ffa33a25e52)
      ✓ should reuse an exisiting kernel
Kernel: starting (c37fca6b0e0180fb59592ffa33a25e52)
Starting WebSocket: ws://localhost:8888/api/kernels/e8a50039fca33307f5855043cb9e5724
      ✓ should connect to a running kernel if given kernel options
Kernel: starting (e8a50039fca33307f5855043cb9e5724)
Starting WebSocket: ws://localhost:8888/api/kernels/708011ed7877db8b439816e968e469c5
      ✓ should accept ajax options
Kernel: starting (708011ed7877db8b439816e968e469c5)
API request failed (400 Bad Request):
      ✓ should fail if no running kernel available
    IKernel
      #statusChanged
Starting WebSocket: ws://localhost:8888/api/kernels/4125393b9a4830dca5a22d80a24a841e
Kernel: starting (4125393b9a4830dca5a22d80a24a841e)
        ✓ should be a signal following the Kernel status
      #iopubMessage
Starting WebSocket: ws://localhost:8888/api/kernels/21818b9c35542187116381e36283d4b6
Kernel: starting (21818b9c35542187116381e36283d4b6)
        ✓ should be emitted for an iopub message
Starting WebSocket: ws://localhost:8888/api/kernels/b9b6ceb2635b33032b66e2cc75a6cffe
Kernel: starting (b9b6ceb2635b33032b66e2cc75a6cffe)
        ✓ should be emitted regardless of the sender
      #unhandledMessage
Starting WebSocket: ws://localhost:8888/api/kernels/29731d2d38b4145bf5169d37fc0ba39c
Kernel: starting (29731d2d38b4145bf5169d37fc0ba39c)
        ✓ should be emitted for an unhandled message
Starting WebSocket: ws://localhost:8888/api/kernels/3efc16438a4f397b557a5c55718c76ce
        ✓ should not be emitted for an iopub signal
Kernel: starting (3efc16438a4f397b557a5c55718c76ce)
Starting WebSocket: ws://localhost:8888/api/kernels/7c726bdca5ebe2880932bc6aa276a47b
        ✓ should not be emitted for a different client session
Kernel: starting (7c726bdca5ebe2880932bc6aa276a47b)
      #id
Starting WebSocket: ws://localhost:8888/api/kernels/3b61f93447c56beec2605f426725045a
        ✓ should be a read only string
Kernel: starting (3b61f93447c56beec2605f426725045a)
      #name
Starting WebSocket: ws://localhost:8888/api/kernels/c3da9cf4c2147b8fb1b7ee2569c7e7eb
        ✓ should be a read only string
Kernel: starting (c3da9cf4c2147b8fb1b7ee2569c7e7eb)
      #username
Starting WebSocket: ws://localhost:8888/api/kernels/13c2d4702159651e6201598e33f0eeed
        ✓ should be a read only string
Kernel: starting (13c2d4702159651e6201598e33f0eeed)
      #clientId
Starting WebSocket: ws://localhost:8888/api/kernels/a1ea614b82ccb42181b9c04e0b9fcf8c
        ✓ should be a read only string
Kernel: starting (a1ea614b82ccb42181b9c04e0b9fcf8c)
      #status
Starting WebSocket: ws://localhost:8888/api/kernels/42ad5cc9cdbdf0e469df1730729fe3ae
Kernel: starting (42ad5cc9cdbdf0e469df1730729fe3ae)
        ✓ should get an idle status
Starting WebSocket: ws://localhost:8888/api/kernels/fcabd677d85e4aa2cc3caac813694184
Kernel: starting (fcabd677d85e4aa2cc3caac813694184)
Kernel: restarting (fcabd677d85e4aa2cc3caac813694184)
        ✓ should get a restarting status
Starting WebSocket: ws://localhost:8888/api/kernels/8cff6eba5c6a8291b45bbe3a26e67a04
Kernel: starting (8cff6eba5c6a8291b45bbe3a26e67a04)
        ✓ should get a busy status
Starting WebSocket: ws://localhost:8888/api/kernels/87bff8c6da8ff4fd9cc812882983ff0b
Kernel: starting (87bff8c6da8ff4fd9cc812882983ff0b)
Kernel: reconnecting (87bff8c6da8ff4fd9cc812882983ff0b)
        ✓ should get a reconnecting status
Connection lost, reconnecting in 1 seconds.
Starting WebSocket: ws://localhost:8888/api/kernels/44ff1580cfa066a941ccfdf65a32e15f
Kernel: starting (44ff1580cfa066a941ccfdf65a32e15f)
Kernel: dead (44ff1580cfa066a941ccfdf65a32e15f)
        ✓ should get a dead status
Starting WebSocket: ws://localhost:8888/api/kernels/7d604f43db50a3c1de92149fc172f55a
Kernel: starting (7d604f43db50a3c1de92149fc172f55a)
invalid kernel status: celebrating
        ✓ should handle an invalid status
      #isDisposed
Starting WebSocket: ws://localhost:8888/api/kernels/8dbec3d3ce5ab11c5a9f6d53b430f0b1
        ✓ should be true after we dispose of the kernel
Starting WebSocket: ws://localhost:8888/api/kernels/21549756b258e9c255d2f5e59ec2b36e
        ✓ should be safe to call multiple times
      #dispose()
Starting WebSocket: ws://localhost:8888/api/kernels/cc2dd56e5541a50b444266d1c5014616
        ✓ should dispose of the resources held by the kernel
Starting WebSocket: ws://localhost:8888/api/kernels/b099da4d42795b0778906b7663220992
        ✓ should be save to call twice
      #sendShellMessage()
Starting WebSocket: ws://localhost:8888/api/kernels/c6780fd0b95d58263cb0b3497aa231a6
Kernel: starting (c6780fd0b95d58263cb0b3497aa231a6)
        ✓ should send a message to the kernel
Starting WebSocket: ws://localhost:8888/api/kernels/e2b17dc02a0e2980b68b4ce4f9684389
Kernel: starting (e2b17dc02a0e2980b68b4ce4f9684389)
        ✓ should send a binary message
Starting WebSocket: ws://localhost:8888/api/kernels/3d4ce613ec54dad6278b63046b2e6a35
Kernel: starting (3d4ce613ec54dad6278b63046b2e6a35)
Kernel: dead (3d4ce613ec54dad6278b63046b2e6a35)
        ✓ should fail if the kernel is dead
Starting WebSocket: ws://localhost:8888/api/kernels/70dc618d13f3510f96abe1498d866fcb
Kernel: starting (70dc618d13f3510f96abe1498d866fcb)
        ✓ should handle out of order messages
      #interrupt()
Starting WebSocket: ws://localhost:8888/api/kernels/5bca8daa259bb97335f9e158ba59f509
Kernel: starting (5bca8daa259bb97335f9e158ba59f509)
        ✓ should interrupt and resolve with a valid server response
Starting WebSocket: ws://localhost:8888/api/kernels/20d28f7bda5cfd5909619a0c0f34a3f4
Kernel: starting (20d28f7bda5cfd5909619a0c0f34a3f4)
        ✓ should use ajax options
Starting WebSocket: ws://localhost:8888/api/kernels/46561e309fecbec3db0fedd59dc38f91
Kernel: starting (46561e309fecbec3db0fedd59dc38f91)
        ✓ should throw an error for an invalid response
Starting WebSocket: ws://localhost:8888/api/kernels/82efc6498d3770f3a53ac400a68cd447
Kernel: starting (82efc6498d3770f3a53ac400a68cd447)
API request failed (500 Internal Server Error):
        ✓ should throw an error for an error response
Starting WebSocket: ws://localhost:8888/api/kernels/7ad9ff97fa21afae05414b91c44c6daf
Kernel: starting (7ad9ff97fa21afae05414b91c44c6daf)
Kernel: dead (7ad9ff97fa21afae05414b91c44c6daf)
        ✓ should fail if the kernel is dead
      #restart()
Starting WebSocket: ws://localhost:8888/api/kernels/96b1fd36d2ab50e2187fb9df90a9766f
Kernel: restarting (96b1fd36d2ab50e2187fb9df90a9766f)
Kernel: starting (96b1fd36d2ab50e2187fb9df90a9766f)
        ✓ should restart and resolve with a valid server response
Starting WebSocket: ws://localhost:8888/api/kernels/80a0f815aa34a89334fe7d11e140ff48
Kernel: restarting (80a0f815aa34a89334fe7d11e140ff48)
Kernel: starting (80a0f815aa34a89334fe7d11e140ff48)
        ✓ should use ajax options
Starting WebSocket: ws://localhost:8888/api/kernels/d612fcaa0808d17d26b9c70afa1ffd9d
Kernel: restarting (d612fcaa0808d17d26b9c70afa1ffd9d)
Kernel: starting (d612fcaa0808d17d26b9c70afa1ffd9d)
API request failed (500 Internal Server Error):
        ✓ should fail if the kernel does not restart
Starting WebSocket: ws://localhost:8888/api/kernels/e42891b394a2202217bffc58bb86830d
Kernel: restarting (e42891b394a2202217bffc58bb86830d)
Kernel: starting (e42891b394a2202217bffc58bb86830d)
        ✓ should throw an error for an invalid response
Starting WebSocket: ws://localhost:8888/api/kernels/7c8217f920ce2fe114d17522425953c2
Kernel: restarting (7c8217f920ce2fe114d17522425953c2)
Kernel: starting (7c8217f920ce2fe114d17522425953c2)
API request failed (500 Internal Server Error):
        ✓ should throw an error for an error response
Starting WebSocket: ws://localhost:8888/api/kernels/7b62a43c738da0623062ed0113f25a86
Kernel: restarting (7b62a43c738da0623062ed0113f25a86)
Kernel: starting (7b62a43c738da0623062ed0113f25a86)
        ✓ should throw an error for an invalid id
Starting WebSocket: ws://localhost:8888/api/kernels/ca071048e09353692e356ba83f416797
Kernel: restarting (ca071048e09353692e356ba83f416797)
Kernel: starting (ca071048e09353692e356ba83f416797)
        ✓ should dispose of existing comm and future objects
      #reconnect()
Starting WebSocket: ws://localhost:8888/api/kernels/96fbcf37077f2f50756d70df03868e69
Kernel: reconnecting (96fbcf37077f2f50756d70df03868e69)
Starting WebSocket: ws://localhost:8888/api/kernels/96fbcf37077f2f50756d70df03868e69
Kernel: starting (96fbcf37077f2f50756d70df03868e69)
        ✓ should reconnect the websocket
Starting WebSocket: ws://localhost:8888/api/kernels/73bbc6636a945361eac1b7eb9c41e109
Kernel: reconnecting (73bbc6636a945361eac1b7eb9c41e109)
Starting WebSocket: ws://localhost:8888/api/kernels/73bbc6636a945361eac1b7eb9c41e109
Kernel: starting (73bbc6636a945361eac1b7eb9c41e109)
        ✓ should emit a `'reconnecting'` status
      #shutdown()
Starting WebSocket: ws://localhost:8888/api/kernels/3f1a674c687975c71a2f8b09421801b4
Kernel: starting (3f1a674c687975c71a2f8b09421801b4)
        ✓ should shut down and resolve with a valid server response
Starting WebSocket: ws://localhost:8888/api/kernels/f6b2074909f9e4bcace41ee198b5358d
Kernel: starting (f6b2074909f9e4bcace41ee198b5358d)
        ✓ should use ajax options
Starting WebSocket: ws://localhost:8888/api/kernels/91405e7cfe7a8049108d3164ad9e29f6
Kernel: starting (91405e7cfe7a8049108d3164ad9e29f6)
        ✓ should throw an error for an invalid response
Starting WebSocket: ws://localhost:8888/api/kernels/f6732bd63525d59a923142603a5f4412
Kernel: starting (f6732bd63525d59a923142603a5f4412)
API request failed (500 Internal Server Error):
        ✓ should throw an error for an error response
Starting WebSocket: ws://localhost:8888/api/kernels/02969695959084deb693dfb717b2bd73
Kernel: starting (02969695959084deb693dfb717b2bd73)
Kernel: dead (02969695959084deb693dfb717b2bd73)
        ✓ should fail if the kernel is dead
      #kernelInfo()
Starting WebSocket: ws://localhost:8888/api/kernels/61f5266da1be1408d87cd7e2dd391f17
Kernel: starting (61f5266da1be1408d87cd7e2dd391f17)
        ✓ should resolve the promise
      #complete()
Starting WebSocket: ws://localhost:8888/api/kernels/934e974ecc877afd652b639fd94016ac
Kernel: starting (934e974ecc877afd652b639fd94016ac)
        ✓ should resolve the promise
Starting WebSocket: ws://localhost:8888/api/kernels/17ee1f29cc7eca5ff384c6477cc2627d
Kernel: starting (17ee1f29cc7eca5ff384c6477cc2627d)
Kernel: dead (17ee1f29cc7eca5ff384c6477cc2627d)
        ✓ should reject the promise if the kernel is dead
      #inspect()
Starting WebSocket: ws://localhost:8888/api/kernels/fe4bc21b00023c8434e5fd85343dcf86
Kernel: starting (fe4bc21b00023c8434e5fd85343dcf86)
        ✓ should resolve the promise
Starting WebSocket: ws://localhost:8888/api/kernels/68de343582f4f80bb87c620eb8c8f538
Kernel: starting (68de343582f4f80bb87c620eb8c8f538)
Kernel: reconnecting (68de343582f4f80bb87c620eb8c8f538)
Connection lost, reconnecting in 1 seconds.
Starting WebSocket: ws://localhost:8888/api/kernels/40db911b5d5904f2bd6dc7290f8984f5
Starting WebSocket: ws://localhost:8888/api/kernels/87bff8c6da8ff4fd9cc812882983ff0b
Starting WebSocket: ws://localhost:8888/api/kernels/68de343582f4f80bb87c620eb8c8f538
Kernel: starting (68de343582f4f80bb87c620eb8c8f538)
        ✓ should delay the promise if the kernel is reconnecting (1005ms)
      #isComplete()
Starting WebSocket: ws://localhost:8888/api/kernels/b6e703f3ac0dc7cc82372cd96886a337
Kernel: starting (b6e703f3ac0dc7cc82372cd96886a337)
        ✓ should resolve the promise
      #history()
Starting WebSocket: ws://localhost:8888/api/kernels/a846204c3b795930fb982d4ab3f70567
Kernel: starting (a846204c3b795930fb982d4ab3f70567)
        ✓ should resolve the promise
      #sendInputReply()
Starting WebSocket: ws://localhost:8888/api/kernels/6c99a5e9c71199146c76f26a96b1b0f0
Kernel: starting (6c99a5e9c71199146c76f26a96b1b0f0)
        ✓ should resolve the promise
Starting WebSocket: ws://localhost:8888/api/kernels/274e746808686f2e20ebc8d78513b3b0
Kernel: starting (274e746808686f2e20ebc8d78513b3b0)
Kernel: dead (274e746808686f2e20ebc8d78513b3b0)
        ✓ should fail if the kernel is dead
      #execute()
Starting WebSocket: ws://localhost:8888/api/kernels/74ab7da7d38ff13be8bffaeeb9cd014e
Kernel: starting (74ab7da7d38ff13be8bffaeeb9cd014e)
        ✓ should send and handle incoming messages
Starting WebSocket: ws://localhost:8888/api/kernels/6d77ac94aac527e5259e37185fc93c70
        ✓ should have a read-only msg attribute
Kernel: starting (6d77ac94aac527e5259e37185fc93c70)
Starting WebSocket: ws://localhost:8888/api/kernels/ac741377233c41b345fd8f1f68b80729
Kernel: starting (ac741377233c41b345fd8f1f68b80729)
        ✓ should not dispose of KernelFuture when disposeOnDone=false
      #getKernelSpec()
Starting WebSocket: ws://localhost:8888/api/kernels/10ce7ddcd5074ed038edc5eca58d883a
Kernel: starting (10ce7ddcd5074ed038edc5eca58d883a)
        ✓ should load the kernelspec
    KernelManager
      #constructor()
        ✓ should take the options as an argument
      #getSpecs()
        ✓ should get the list of kernel specs
      #listRunning()
        ✓ should list the running kernels
      #startNew()
Starting WebSocket: ws://localhost:8888/api/kernels/bea5171f11d3a7ba41296ed8aad3bc83
Kernel: starting (bea5171f11d3a7ba41296ed8aad3bc83)
        ✓ should start a new kernel
      #findById()
Starting WebSocket: ws://localhost:8888/api/kernels/bcc1fe96e1a63e6bb6ea6d5821ef725d
        ✓ should find an existing kernel by id
Kernel: starting (bcc1fe96e1a63e6bb6ea6d5821ef725d)
      #connectTo()
Starting WebSocket: ws://localhost:8888/api/kernels/ecbc81db5a8de6223193358b22934120
Starting WebSocket: ws://localhost:8888/api/kernels/ecbc81db5a8de6223193358b22934120
        ✓ should connect to an existing kernel
Kernel: starting (ecbc81db5a8de6223193358b22934120)
Kernel: starting (ecbc81db5a8de6223193358b22934120)
    getKernelSpecs()
      ✓ should load the kernelspecs
      ✓ should accept ajax options
      ✓ should throw an error for missing default parameter
      ✓ should throw an error for missing kernelspecs parameter
      ✓ should throw an error for incorrect kernelspecs parameter type
      ✓ should throw an error for improper name
      ✓ should throw an error for improper language
      ✓ should throw an error for improper argv
      ✓ should throw an error for improper display_name
      ✓ should throw an error for missing resources
      ✓ should throw an error for an invalid response
    #isStreamMsg()
      ✓ should check for a stream message type
    #isDisplayDataMsg()
      ✓ should check for a display data message type
    #isExecuteInputMsg()
      ✓ should check for a execute input message type
    #isExecuteResultMsg()
      ✓ should check for an execute result message type
    #isStatusMsg()
      ✓ should check for a status message type
    #isClearOutputMsg()
      ✓ should check for a clear output message type
    #isCommOpenMsg()
      ✓ should check for a comm open message type
    #isErrorMsg()
      ✓ should check for an message type

  mockkernel
    MockKernel
      #constructor()
        ✓ should accept no arguments
        ✓ should accept a kernel model
      #interrupt()
        ✓ should change the status to busy then idle
      #restart()
        ✓ should change the status to restarting then idle
      #kernelInfo()
        ✓ should get the kernel info for the mock kernel
      #execute()
        ✓ should execute the code on the mock kernel
        ✓ should emit one iopub stream message
        ✓ should increment the execution count
        ✓ should allow two executions in a row
        ✓ should error remaining executes if `stop_on_error` and an error occurs
      #getKernelSpec()
        ✓ should get the kernel spec for the mock kernel

  jupyter.services - session
    listRunningSessions()
      ✓ should yield a list of valid session models
      ✓ should accept ajax options
      ✓ should throw an error for an invalid model
      ✓ should throw an error for another invalid model
      ✓ should fail for wrong response status
API request failed (500):  500 Internal Server Error
      ✓ should fail for error response status
Starting WebSocket: ws://localhost:8888/api/kernels/1b8fb92bf7178b5409dbdfac0d48b9a0
Kernel: starting (1b8fb92bf7178b5409dbdfac0d48b9a0)
Starting WebSocket: ws://localhost:8888/api/kernels/buzz
      ✓ should update an existing session
Kernel: starting (buzz)
    startNewSession()
Starting WebSocket: ws://localhost:8888/api/kernels/66ceb940d13986b5f2a6e9196b3c71de
Kernel: starting (66ceb940d13986b5f2a6e9196b3c71de)
      ✓ should start a session
Starting WebSocket: ws://localhost:8888/api/kernels/ac554320558e4f04a9c8ad52b24025a1
Kernel: starting (ac554320558e4f04a9c8ad52b24025a1)
Starting WebSocket: ws://localhost:8888/api/kernels/ac554320558e4f04a9c8ad52b24025a1
Kernel: starting (ac554320558e4f04a9c8ad52b24025a1)
      ✓ should be able connect to an existing kernel
Starting WebSocket: ws://localhost:8888/api/kernels/3f2e46bd81072e911a6b30a72d5e615b
Kernel: starting (3f2e46bd81072e911a6b30a72d5e615b)
      ✓ should accept ajax options
Starting WebSocket: ws://localhost:8888/api/kernels/48e37946731cffb8ad896e304a357ea1
Kernel: dead (48e37946731cffb8ad896e304a357ea1)
      ✓ should start even if the websocket fails
      ✓ should fail for wrong response status
API request failed (500):  500 Internal Server Error
      ✓ should fail for error response status
      ✓ should fail for wrong response model
API request failed (400 Bad Request):
      ✓ should fail if the kernel is not running
    findSessionByPath()
      ✓ should find an existing session by path
    findSessionById()
      ✓ should find an existing session by id
    connectToSession()
Starting WebSocket: ws://localhost:8888/api/kernels/e2fff1eca5fff819cfb34c6dac69bce8
Kernel: starting (e2fff1eca5fff819cfb34c6dac69bce8)
Starting WebSocket: ws://localhost:8888/api/kernels/e2fff1eca5fff819cfb34c6dac69bce8
      ✓ should connect to a running session
Kernel: starting (e2fff1eca5fff819cfb34c6dac69bce8)
Starting WebSocket: ws://localhost:8888/api/kernels/37094d0e7597647a9698d595a85633fe
Kernel: starting (37094d0e7597647a9698d595a85633fe)
      ✓ should connect to a client session if given session options
Starting WebSocket: ws://localhost:8888/api/kernels/a124ec2fc1b7228870d71a57f117bf63
Kernel: starting (a124ec2fc1b7228870d71a57f117bf63)
      ✓ should accept ajax options
API request failed (500):  500 Internal Server Error
      ✓ should fail if session is not available
    ISession
      #sessionDied
Starting WebSocket: ws://localhost:8888/api/kernels/63418073630d0d891374b6ba466339dd
Kernel: starting (63418073630d0d891374b6ba466339dd)
        ✓ should emit when the session is shut down
      #kernelChanged
Starting WebSocket: ws://localhost:8888/api/kernels/4dfe954ae2c5a37d93d148f2f31780ba
Kernel: starting (4dfe954ae2c5a37d93d148f2f31780ba)
Starting WebSocket: ws://localhost:8888/api/kernels/baz
        ✓ should emit when the kernel changes
      #statusChanged
Starting WebSocket: ws://localhost:8888/api/kernels/362a53b69ea2bc8911b0290c9bc16d5b
Kernel: starting (362a53b69ea2bc8911b0290c9bc16d5b)
        ✓ should emit when the kernel status changes
      #iopubMessage
Starting WebSocket: ws://localhost:8888/api/kernels/243573b47cca65889a25ce27515aaff9
Kernel: starting (243573b47cca65889a25ce27515aaff9)
        ✓ should be emitted for an iopub message
      #unhandledMessage
Starting WebSocket: ws://localhost:8888/api/kernels/8dc1fbaba98112f1a69e9f0f10de8c5b
Kernel: starting (8dc1fbaba98112f1a69e9f0f10de8c5b)
        ✓ should be emitted for an unhandled message
      #pathChanged
Starting WebSocket: ws://localhost:8888/api/kernels/dcb53fe8c84522d7ecd01e9b83270335
Kernel: starting (dcb53fe8c84522d7ecd01e9b83270335)
        ✓ should be emitted when the session path changes
      #id
Starting WebSocket: ws://localhost:8888/api/kernels/3fe63edbe94c1c8df1f1ec933c72e6ee
Kernel: starting (3fe63edbe94c1c8df1f1ec933c72e6ee)
        ✓ should be a read only string
      #path
Starting WebSocket: ws://localhost:8888/api/kernels/686050689cacacb5dccb738c54e84ed1
Kernel: starting (686050689cacacb5dccb738c54e84ed1)
        ✓ should be a read only string
      #kernel
Starting WebSocket: ws://localhost:8888/api/kernels/0473d432ea648a0c749f985b3539d068
Kernel: starting (0473d432ea648a0c749f985b3539d068)
        ✓ should be a read only IKernel object
      #kernel
Starting WebSocket: ws://localhost:8888/api/kernels/47b1322979f2f1402e7ce02444b59590
Kernel: starting (47b1322979f2f1402e7ce02444b59590)
        ✓ should be a read only delegate to the kernel status
      #isDisposed
Starting WebSocket: ws://localhost:8888/api/kernels/8a15cde684976837d4fedd429f660e20
Kernel: starting (8a15cde684976837d4fedd429f660e20)
        ✓ should be true after we dispose of the session
Starting WebSocket: ws://localhost:8888/api/kernels/7d07be8401b059ab187f1a05e0ddfa26
Kernel: starting (7d07be8401b059ab187f1a05e0ddfa26)
        ✓ should be safe to call multiple times
      #dispose()
Starting WebSocket: ws://localhost:8888/api/kernels/b2c05360b89d1c3ce5c50bcc6702f37a
Kernel: starting (b2c05360b89d1c3ce5c50bcc6702f37a)
        ✓ should dispose of the resources held by the session
Starting WebSocket: ws://localhost:8888/api/kernels/08f7ea983e701123852f1c36333bce30
Kernel: starting (08f7ea983e701123852f1c36333bce30)
        ✓ should be safe to call twice
Starting WebSocket: ws://localhost:8888/api/kernels/f734e51bdd2815ea098b93fc73609faf
Kernel: starting (f734e51bdd2815ea098b93fc73609faf)
        ✓ should be safe to call if the kernel is disposed
      #rename()
Starting WebSocket: ws://localhost:8888/api/kernels/c328b1cbc8053ac6395cf2cdf67efca3
Kernel: starting (c328b1cbc8053ac6395cf2cdf67efca3)
        ✓ should rename the session
Starting WebSocket: ws://localhost:8888/api/kernels/e6a5a11562d397ee66e85aa60e70d5a8
Kernel: starting (e6a5a11562d397ee66e85aa60e70d5a8)
        ✓ should fail for improper response status
Starting WebSocket: ws://localhost:8888/api/kernels/08ba8aa653107e32627f838a79d2b578
Kernel: starting (08ba8aa653107e32627f838a79d2b578)
API request failed (500):  500 Internal Server Error
        ✓ should fail for error response status
Starting WebSocket: ws://localhost:8888/api/kernels/bd6ae0337e1cfdf2884de1f1fe6440cd
Kernel: starting (bd6ae0337e1cfdf2884de1f1fe6440cd)
        ✓ should fail for improper model
Starting WebSocket: ws://localhost:8888/api/kernels/b65c5eff5ec4f7793763f50acafa5b0d
Kernel: starting (b65c5eff5ec4f7793763f50acafa5b0d)
        ✓ should fail if the session is disposed
      #changeKernel()
Starting WebSocket: ws://localhost:8888/api/kernels/fe54a41574ce90df2eb2a058be03fd14
Kernel: starting (fe54a41574ce90df2eb2a058be03fd14)
Starting WebSocket: ws://localhost:8888/api/kernels/4e627ff7595410ffa3ee7c2021d83253
Kernel: starting (4e627ff7595410ffa3ee7c2021d83253)
        ✓ should create a new kernel with the new name
Starting WebSocket: ws://localhost:8888/api/kernels/080562f83df39f7b1f49ca611e5319c1
Kernel: starting (080562f83df39f7b1f49ca611e5319c1)
Starting WebSocket: ws://localhost:8888/api/kernels/ab29693b9677c4ce3a4248fbdfed3776
Kernel: starting (ab29693b9677c4ce3a4248fbdfed3776)
        ✓ should accept the id of the new kernel
Starting WebSocket: ws://localhost:8888/api/kernels/78c9f76dd13aae1011b262c55908fe43
Kernel: starting (78c9f76dd13aae1011b262c55908fe43)
Starting WebSocket: ws://localhost:8888/api/kernels/5e8bf8804f3844fc54d7e218ea3902bc
Kernel: starting (5e8bf8804f3844fc54d7e218ea3902bc)
        ✓ should work when there is no current kernel
Starting WebSocket: ws://localhost:8888/api/kernels/bec35e8da54ac768f08c9fc3e5076a56
Kernel: starting (bec35e8da54ac768f08c9fc3e5076a56)
Starting WebSocket: ws://localhost:8888/api/kernels/8da44fad43923c2bfd86c183525cb123
Kernel: starting (8da44fad43923c2bfd86c183525cb123)
        ✓ should update the session path if it has changed
      #shutdown()
Starting WebSocket: ws://localhost:8888/api/kernels/2651b1ed1576a6a67ead12da7922b265
Kernel: starting (2651b1ed1576a6a67ead12da7922b265)
        ✓ should shut down properly
Starting WebSocket: ws://localhost:8888/api/kernels/d2f02ea304c1d686a31540bb1b3f530c
Kernel: starting (d2f02ea304c1d686a31540bb1b3f530c)
        ✓ should emit a sessionDied signal
Starting WebSocket: ws://localhost:8888/api/kernels/87a08b193697dca39954311d991af6c1
Kernel: starting (87a08b193697dca39954311d991af6c1)
        ✓ should accept ajax options
Starting WebSocket: ws://localhost:8888/api/kernels/dd2192674c4181b7e0d0bcdb3e1f33ff
Kernel: starting (dd2192674c4181b7e0d0bcdb3e1f33ff)
        ✓ should fail for an incorrect response status
Starting WebSocket: ws://localhost:8888/api/kernels/08cf601b83d37d92389d9ebdf0fbf5bf
Kernel: starting (08cf601b83d37d92389d9ebdf0fbf5bf)
        ✓ should handle a specific error status
Starting WebSocket: ws://localhost:8888/api/kernels/7fce3b44617ee8cde81dc40d3aeca61b
Kernel: starting (7fce3b44617ee8cde81dc40d3aeca61b)
API request failed (500):  500 Internal Server Error
        ✓ should fail for an error response status
Starting WebSocket: ws://localhost:8888/api/kernels/ea65683dc90410eba0f34d402f5f4620
Kernel: starting (ea65683dc90410eba0f34d402f5f4620)
        ✓ should fail if the session is disposed
    SessionManager
      #constructor()
        ✓ should take the options as an argument
      #listRunning()
        ✓ should a return list of session ids
      #startNew()
Starting WebSocket: ws://localhost:8888/api/kernels/4a90c0051c30312b806d5e590af76ef5
Kernel: starting (4a90c0051c30312b806d5e590af76ef5)
        ✓ should start a session
      #findByPath()
Starting WebSocket: ws://localhost:8888/api/kernels/13084eff50f21ca1ae68c25260c098d5
Kernel: starting (13084eff50f21ca1ae68c25260c098d5)
        ✓ should find an existing session by path
      #findById()
Starting WebSocket: ws://localhost:8888/api/kernels/96120af13bbb41962257b81238cece0a
Kernel: starting (96120af13bbb41962257b81238cece0a)
        ✓ should find an existing session by id
      #connectTo()
Starting WebSocket: ws://localhost:8888/api/kernels/cf459e957eddd2a1c0321067fc82ee90
Kernel: starting (cf459e957eddd2a1c0321067fc82ee90)
Starting WebSocket: ws://localhost:8888/api/kernels/cf459e957eddd2a1c0321067fc82ee90
        ✓ should connect to a running session
Kernel: starting (cf459e957eddd2a1c0321067fc82ee90)

  jupyter.services
    validateKernelMessage
      ✓ should pass a valid message
      ✓ should throw if missing a field
      ✓ should throw if a field is invalid
      ✓ should throw if the parent header is given an invalid
      ✓ should throw if the channel is not a string
      ✓ should validate an iopub message
      ✓ should throw on an an iopub message type
      ✓ should throw on missing iopub message content
      ✓ should throw on invalid iopub message content
    #validateKernelModel()
      ✓ should pass a valid id
      ✓ should fail on missing data
      ✓ should fail on incorrect data
    #validateSessionModel()
      ✓ should pass a valid id
      ✓ should fail on missing data
      ✓ should fail on incorrect data
    #validateKernelSpecModel
      ✓ should pass with valid data
      ✓ should fail on missing data
      ✓ should fail on incorrect data
    validateContentsModel()
      ✓ should pass with valid data
      ✓ should fail on missing data
      ✓ should fail on incorrect data
    validateCheckpointModel()
      ✓ should pass with valid data
      ✓ should fail on missing data
      ✓ should fail on incorrect data
  282 passing (2s)
````