### PR TITLE
Clean up futures handling in mock kernel

### DIFF
--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -938,7 +938,7 @@ namespace KernelMessage {
       cursor_start: number;
       cursor_end: number;
       metadata: JSONObject;
-      status: string;
+      status: 'ok' | 'error';
     };
   }
 


### PR DESCRIPTION
@afshin, now you can write:

```typescript
let kernel = new MockKernel();
kernel.history().then(...);
kernel.sendShellReply(<fake history content>);
```