### PR TITLE
Kernel message filters

### DIFF
--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -286,7 +286,7 @@ interface IKernel extends IDisposable {
    * #### Notes
    * If the callback returns false, the message processing will stop.
    */
-  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean):  IDisposable;
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable;
 
   /**
    * Get the kernel spec associated with the kernel.
@@ -297,15 +297,6 @@ interface IKernel extends IDisposable {
    * Optional default settings for ajax requests, if applicable.
    */
   ajaxSettings?: IAjaxSettings;
-}
-
-export
-interface IHookList<T> extends IDisposable {
-  add(hook: (msg: T) => boolean): void;
-
-  remove(hook: (msg: T) => boolean): void;
-
-  process(msg: T): boolean;
 }
 
 /**
@@ -428,9 +419,15 @@ namespace IKernel {
     onDone: () => void;
 
     /**
-     * The message hooks
+     * Register hook for IOPub messages.
+     * 
+     * @returns a disposable to unregister the hook.
+     * 
+     * #### Notes
+     * The most recently-registered hook is run first.
      */
-    hooks: IHookList<KernelMessage.IIOPubMessage>;
+    registerMessageHook(hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
+    removeMessageHook(hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
   }
 
   /**

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -275,6 +275,15 @@ interface IKernel extends IDisposable {
   registerCommTarget(targetName: string, callback: (comm: IKernel.IComm, msg: KernelMessage.ICommOpenMsg) => void): IDisposable;
 
   /**
+   * Register an iopub message hook.
+   *
+   * TODO: we could also return a disposable to remove the message hook, but that would mean that you have to store it to be able to delete it. For some reason, I thought it would be better to have an explicit way to deregister a hook.
+   */
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
+  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
+
+
+  /**
    * Get the kernel spec associated with the kernel.
    */
   getKernelSpec(): Promise<IKernel.ISpec>;
@@ -285,6 +294,14 @@ interface IKernel extends IDisposable {
   ajaxSettings?: IAjaxSettings;
 }
 
+export
+interface IHookList<T> extends IDisposable {
+  add(hook: (msg: T) => boolean): void;
+
+  remove(hook: (msg: T) => boolean): void;
+
+  process(msg: T): boolean;
+}
 
 /**
  * A namespace for kernel types, interfaces, and type checker functions.
@@ -404,6 +421,11 @@ namespace IKernel {
      * The done handler for the kernel future.
      */
     onDone: () => void;
+
+    /**
+     * The message hooks
+     */
+    hooks: IHookList<KernelMessage.IIOPubMessage>;
   }
 
   /**

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -420,13 +420,27 @@ namespace IKernel {
 
     /**
      * Register hook for IOPub messages.
-     * 
-     * @returns a disposable to unregister the hook.
-     * 
+     *
+     * @param hook - The callback invoked for an IOPub message.
+     *
      * #### Notes
-     * The most recently-registered hook is run first.
+     * The IOPub hook system allows you to preempt the handlers for IOPub messages handled
+     * by the future. The most recently registered hook is run first.
+     * If the hook returns false, any later hooks and the future's onIOPub handler will not run.
+     * If a hook throws an error, the error is logged to the console and the next hook is run.
+     * If a hook is registered during the hook processing, it won't run until the next message.
+     * If a hook is removed during the hook processing, it will be deactivated immediately.
      */
     registerMessageHook(hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
+
+    /**
+     * Remove a hook for IOPub messages.
+     *
+     * @param hook - The hook to remove.
+     *
+     * #### Notes
+     * If a hook is removed during the hook processing, it will be deactivated immediately.
+     */
     removeMessageHook(hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
   }
 

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -275,13 +275,18 @@ interface IKernel extends IDisposable {
   registerCommTarget(targetName: string, callback: (comm: IKernel.IComm, msg: KernelMessage.ICommOpenMsg) => void): IDisposable;
 
   /**
-   * Register an iopub message hook.
+   * Register an IOPub message hook.
    *
-   * TODO: we could also return a disposable to remove the message hook, but that would mean that you have to store it to be able to delete it. For some reason, I thought it would be better to have an explicit way to deregister a hook.
+   * @param msg_id - The message id the hook will intercept.
+   *
+   * @param hook - The callback invoked for the message.
+   *
+   * @returns A disposable used to unregister the message hook
+   *
+   * #### Notes
+   * If the callback returns false, the message processing will stop.
    */
-  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
-  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
-
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean):  IDisposable;
 
   /**
    * Get the kernel spec associated with the kernel.

--- a/src/ikernel.ts
+++ b/src/ikernel.ts
@@ -277,14 +277,21 @@ interface IKernel extends IDisposable {
   /**
    * Register an IOPub message hook.
    *
-   * @param msg_id - The message id the hook will intercept.
+   * @param msg_id - The parent_header message id in messages the hook should intercept.
    *
    * @param hook - The callback invoked for the message.
    *
-   * @returns A disposable used to unregister the message hook
+   * @returns A disposable used to unregister the message hook.
    *
    * #### Notes
-   * If the callback returns false, the message processing will stop.
+   * The IOPub hook system allows you to preempt the handlers for IOPub messages with a
+   * given parent_header message id. The most recently registered hook is run first.
+   * If the hook returns false, any later hooks and the future's onIOPub handler will not run.
+   * If a hook throws an error, the error is logged to the console and the next hook is run.
+   * If a hook is registered during the hook processing, it won't run until the next message.
+   * If a hook is disposed during the hook processing, it will be deactivated immediately.
+   *
+   * See also [[IFuture.registerMessageHook]].
    */
   registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable;
 

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -788,14 +788,14 @@ class Kernel implements IKernel {
   registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable {
     let future = this._futures && this._futures.get(msg_id);
     if (future) {
-      Private.hooksProperty.get(future).add(hook);
+      future.registerMessageHook(hook);
     }
     return new DisposableDelegate(() => {
       let future = this._futures && this._futures.get(msg_id);
       if (future) {
-        Private.hooksProperty.get(future).remove(hook);
+        future.removeMessageHook(hook);
       }
-    })
+    });
   }
 
   /**

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -789,6 +789,8 @@ class Kernel implements IKernel {
    * If a hook throws an error, the error is logged to the console and the next hook is run.
    * If a hook is registered during the hook processing, it won't run until the next message.
    * If a hook is disposed during the hook processing, it will be deactivated immediately.
+   *
+   * See also [[IFuture.registerMessageHook]].
    */
   registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable {
     let future = this._futures && this._futures.get(msg_id);

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -775,22 +775,27 @@ class Kernel implements IKernel {
 
   /**
    * Register message hook
+   *
+   * @param msg_id - The message id the hook will intercept.
+   *
+   * @param hook - The callback invoked for the message.
+   *
+   * @returns A disposable used to unregister the message hook
+   *
+   * #### Notes
+   * If the callback returns false, the message processing will stop.
    */
-  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void {
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable {
     let future = this._futures && this._futures.get(msg_id);
     if (future) {
-      future.hooks.add(hook)
+      Private.hooksProperty.get(future).add(hook);
     }
-  }
-
-  /**
-   * Remove message hook
-   */
-  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void {
-    let future = this._futures && this._futures.get(msg_id);
-    if (future) {
-      future.hooks.remove(hook)
-    }
+    return new DisposableDelegate(() => {
+      let future = this._futures && this._futures.get(msg_id);
+      if (future) {
+        Private.hooksProperty.get(future).remove(hook);
+      }
+    })
   }
 
   /**

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -774,6 +774,26 @@ class Kernel implements IKernel {
   }
 
   /**
+   * Register message hook
+   */
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void {
+    let future = this._futures && this._futures.get(msg_id);
+    if (future) {
+      future.hooks.add(hook)
+    }
+  }
+
+  /**
+   * Remove message hook
+   */
+  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void {
+    let future = this._futures && this._futures.get(msg_id);
+    if (future) {
+      future.hooks.remove(hook)
+    }
+  }
+
+  /**
    * Register a comm target handler.
    *
    * @param targetName - The name of the comm target.

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -774,16 +774,21 @@ class Kernel implements IKernel {
   }
 
   /**
-   * Register message hook
+   * Register an IOPub message hook.
    *
-   * @param msg_id - The message id the hook will intercept.
+   * @param msg_id - The parent_header message id the hook will intercept.
    *
    * @param hook - The callback invoked for the message.
    *
-   * @returns A disposable used to unregister the message hook
+   * @returns A disposable used to unregister the message hook.
    *
    * #### Notes
-   * If the callback returns false, the message processing will stop.
+   * The IOPub hook system allows you to preempt the handlers for IOPub messages with a
+   * given parent_header message id. The most recently registered hook is run first.
+   * If the hook returns false, any later hooks and the future's onIOPub handler will not run.
+   * If a hook throws an error, the error is logged to the console and the next hook is run.
+   * If a hook is registered during the hook processing, it won't run until the next message.
+   * If a hook is disposed during the hook processing, it will be deactivated immediately.
    */
   registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable {
     let future = this._futures && this._futures.get(msg_id);

--- a/src/kernelfuture.ts
+++ b/src/kernelfuture.ts
@@ -168,9 +168,8 @@ class KernelFutureHandler extends DisposableDelegate implements IKernel.IFuture 
   }
 
   private _handleStdin(msg: KernelMessage.IStdinMessage): void {
-    //let process = this._hooks.process(msg);
     let stdin = this._stdin;
-    if (/*process && */stdin) { stdin(msg); }
+    if (stdin) { stdin(msg); }
   }
 
   private _handleIOPub(msg: KernelMessage.IIOPubMessage): void {

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -401,6 +401,16 @@ class MockKernel implements IKernel {
   }
 
   /**
+   * Register message hook
+   */
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void { }
+
+  /**
+   * Remove message hook
+   */
+  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void { }
+
+  /**
    * Send a messaage to the mock kernel.
    */
   private _sendKernelMessage(msgType: string, channel: KernelMessage.Channel, content: JSONObject): Promise<KernelMessage.IShellMessage> {

--- a/src/mockkernel.ts
+++ b/src/mockkernel.ts
@@ -6,7 +6,7 @@ import * as utils
   from 'jupyter-js-utils';
 
 import {
-  IDisposable
+  IDisposable, DisposableDelegate
 } from 'phosphor-disposable';
 
 import {
@@ -401,14 +401,11 @@ class MockKernel implements IKernel {
   }
 
   /**
-   * Register message hook
+   * Register a message hook
    */
-  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void { }
-
-  /**
-   * Remove message hook
-   */
-  removeMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): void { }
+  registerMessageHook(msg_id: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean): IDisposable { 
+    return new DisposableDelegate(() => {});
+  }
 
   /**
    * Send a messaage to the mock kernel.

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -1247,7 +1247,8 @@ describe('jupyter.services - kernel', () => {
     });
 
     context('#registerMessageHook()', () => {
-            it('should have the most recently registered hook run first', (done) => {
+
+      it('should have the most recently registered hook run first', (done) => {
         let tester = new KernelTester();
         createKernel(tester).then(kernel => {
           let options: KernelMessage.IExecuteRequest = {
@@ -1301,11 +1302,9 @@ describe('jupyter.services - kernel', () => {
                 done();
               });
             };
-
           });
         });
       });
-
 
       it('should abort processing if a hook returns false, but the done logic should still work', (done) => {
         let tester = new KernelTester();
@@ -1360,7 +1359,6 @@ describe('jupyter.services - kernel', () => {
                 done();
               });
             };
-
           });
         });
       });
@@ -1411,17 +1409,16 @@ describe('jupyter.services - kernel', () => {
             };
 
             future.onDone = () => {
-              expect(calls).to.eql([ 'last', 'iopub', 'first', 'last', 'iopub' ]);
+              expect(calls).to.eql(['last', 'iopub', 'first', 'last', 'iopub']);
               doLater(() => {
                 done();
               });
             };
-
           });
         });
       });
 
-      it('removing a message hook in another message hook deactivates it immediately', (done) => {
+      it('should deactivate a hook immediately on removal', (done) => {
         let tester = new KernelTester();
         createKernel(tester).then(kernel => {
           let options: KernelMessage.IExecuteRequest = {
@@ -1473,7 +1470,7 @@ describe('jupyter.services - kernel', () => {
             };
 
             future.onDone = () => {
-              expect(calls).to.eql([ 'first', 'delete', 'iopub', 'first', 'iopub' ]);
+              expect(calls).to.eql(['first', 'delete', 'iopub', 'first', 'iopub']);
               doLater(() => {
                 done();
               });
@@ -1481,21 +1478,22 @@ describe('jupyter.services - kernel', () => {
           });
         });
       });
-    })
-
+    });
   });
 
   describe('IFuture', () => {
+
     it('should have a read-only msg attribute', (done) => {
-        createKernel().then(kernel => {
-          let future = kernel.execute({ code: 'hello' });
-          expect(typeof future.msg.header.msg_id).to.be('string');
-          expect(() => { future.msg = null; }).to.throwError();
-          done();
-        });
+      createKernel().then(kernel => {
+        let future = kernel.execute({ code: 'hello' });
+        expect(typeof future.msg.header.msg_id).to.be('string');
+        expect(() => { future.msg = null; }).to.throwError();
+        done();
+      });
     });
 
     describe('Message hooks', () => {
+
       it('should have the most recently registered hook run first', (done) => {
         let tester = new KernelTester();
         createKernel(tester).then(kernel => {
@@ -1556,11 +1554,9 @@ describe('jupyter.services - kernel', () => {
                 done();
               });
             };
-
           });
         });
       });
-
 
       it('should abort processing if a hook returns false, but the done logic should still work', (done) => {
         let tester = new KernelTester();
@@ -1615,7 +1611,6 @@ describe('jupyter.services - kernel', () => {
                 done();
               });
             };
-
           });
         });
       });
@@ -1666,17 +1661,16 @@ describe('jupyter.services - kernel', () => {
             };
 
             future.onDone = () => {
-              expect(calls).to.eql([ 'last', 'iopub', 'first', 'last', 'iopub' ]);
+              expect(calls).to.eql(['last', 'iopub', 'first', 'last', 'iopub']);
               doLater(() => {
                 done();
               });
             };
-
           });
         });
       });
 
-      it('removing a message hook in another message hook deactivates it immediately', (done) => {
+      it('should deactivate message hooks immediately on removal', (done) => {
         let tester = new KernelTester();
         createKernel(tester).then(kernel => {
           let options: KernelMessage.IExecuteRequest = {
@@ -1728,7 +1722,7 @@ describe('jupyter.services - kernel', () => {
             };
 
             future.onDone = () => {
-              expect(calls).to.eql([ 'first', 'delete', 'iopub', 'first', 'iopub' ]);
+              expect(calls).to.eql(['first', 'delete', 'iopub', 'first', 'iopub']);
               doLater(() => {
                 done();
               });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -33,6 +33,16 @@ let PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
 PYTHON3_SPEC.name = 'Python3';
 PYTHON3_SPEC.spec.display_name = 'python3';
 
+let createMsg = (channel: KernelMessage.Channel, parent_header: JSONObject): KernelMessage.IMessage => {
+  return {
+    channel: channel,
+    parent_header: JSON.parse(JSON.stringify(parent_header)),
+    content: {},
+    header: JSON.parse(JSON.stringify(parent_header)),
+    metadata: {},
+    buffers: []
+  }
+}
 
 describe('jupyter.services - kernel', () => {
 
@@ -1154,15 +1164,6 @@ describe('jupyter.services - kernel', () => {
         });
       });
 
-      it('should have a read-only msg attribute', (done) => {
-         createKernel().then(kernel => {
-           let future = kernel.execute({ code: 'hello' });
-           expect(typeof future.msg.header.msg_id).to.be('string');
-           expect(() => { future.msg = null; }).to.throwError();
-           done();
-         });
-      });
-
       it('should not dispose of KernelFuture when disposeOnDone=false', (done) => {
         let tester = new KernelTester();
         createKernel(tester).then(kernel => {
@@ -1245,6 +1246,497 @@ describe('jupyter.services - kernel', () => {
 
     });
 
+    context('#registerMessageHook()', () => {
+            it('should have the most recently registered hook run first', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              calls.push('last');
+              return true;
+            });
+
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              calls.push('first');
+              // not returning should also continue handling
+              return void 0;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              // the last hook was called for the stream and the status message.
+              expect(calls).to.eql(['first', 'last', 'iopub', 'first', 'last', 'iopub']);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+
+      it('should abort processing if a hook returns false, but the done logic should still work', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              calls.push('last');
+              return true;
+            });
+
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              calls.push('first');
+              return false;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              // the last hook was called for the stream and the status message.
+              expect(calls).to.eql(['first', 'first']);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+      it('should process additions on the next run', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              calls.push('last');
+              kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+                calls.push('first');
+                return true;
+              });
+              return true;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              expect(calls).to.eql([ 'last', 'iopub', 'first', 'last', 'iopub' ]);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+      it('removing a message hook in another message hook deactivates it immediately', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            let toDelete = (msg: KernelMessage.IIOPubMessage) => {
+              calls.push('delete');
+              return true;
+            }
+            let toDeleteHook = kernel.registerMessageHook(parent_header.msg_id, toDelete);
+
+            kernel.registerMessageHook(parent_header.msg_id, (msg) => {
+              if (calls.length > 0) {
+                // delete the hook the second time around
+                toDeleteHook.dispose();
+              }
+              calls.push('first');
+              return true;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              expect(calls).to.eql([ 'first', 'delete', 'iopub', 'first', 'iopub' ]);
+              doLater(() => {
+                done();
+              });
+            };
+          });
+        });
+      });
+    })
+
+  });
+
+  describe('IFuture', () => {
+    it('should have a read-only msg attribute', (done) => {
+        createKernel().then(kernel => {
+          let future = kernel.execute({ code: 'hello' });
+          expect(typeof future.msg.header.msg_id).to.be('string');
+          expect(() => { future.msg = null; }).to.throwError();
+          done();
+        });
+    });
+
+    describe('Message hooks', () => {
+      it('should have the most recently registered hook run first', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            future.registerMessageHook((msg) => {
+              calls.push('last');
+              return true;
+            });
+
+            future.registerMessageHook((msg) => {
+              calls.push('first');
+              // Check to make sure we actually got the messages we expected.
+              if (msg.header.msg_type === 'stream') {
+                expect((msg as KernelMessage.IStreamMsg).content.text).to.be('foo1');
+              } else {
+                expect((msg as KernelMessage.IStatusMsg).content.execution_state).to.be('idle');
+              }
+              // not returning should also continue handling
+              return void 0;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              // the last hook was called for the stream and the status message.
+              expect(calls).to.eql(['first', 'last', 'iopub', 'first', 'last', 'iopub']);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+
+      it('should abort processing if a hook returns false, but the done logic should still work', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            future.registerMessageHook((msg) => {
+              calls.push('last');
+              return true;
+            });
+
+            future.registerMessageHook((msg) => {
+              calls.push('first');
+              return false;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              // the last hook was called for the stream and the status message.
+              expect(calls).to.eql(['first', 'first']);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+      it('should process additions on the next run', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            future.registerMessageHook((msg) => {
+              calls.push('last');
+              future.registerMessageHook((msg) => {
+                calls.push('first');
+                return true;
+              });
+              return true;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              expect(calls).to.eql([ 'last', 'iopub', 'first', 'last', 'iopub' ]);
+              doLater(() => {
+                done();
+              });
+            };
+
+          });
+        });
+      });
+
+      it('removing a message hook in another message hook deactivates it immediately', (done) => {
+        let tester = new KernelTester();
+        createKernel(tester).then(kernel => {
+          let options: KernelMessage.IExecuteRequest = {
+            code: 'test',
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: false
+          };
+          let future = kernel.execute(options, false);
+          tester.onMessage((message) => {
+            // send a reply
+            let parent_header = message.header;
+            let msg = createMsg('shell', parent_header);
+            tester.send(msg);
+
+            future.onReply = () => {
+              // trigger onIOPub with a 'stream' message
+              let msgStream = createMsg('iopub', parent_header);
+              msgStream.header.msg_type = 'stream';
+              msgStream.content = { 'name': 'stdout', 'text': 'foo' };
+              tester.send(msgStream);
+              // trigger onDone
+              let msgDone = createMsg('iopub', parent_header);
+              msgDone.header.msg_type = 'status';
+              (msgDone as KernelMessage.IStatusMsg).content.execution_state = 'idle';
+              tester.send(msgDone);
+            };
+
+            let calls: string[] = [];
+            let toDelete = (msg: KernelMessage.IIOPubMessage) => {
+              calls.push('delete');
+              return true;
+            }
+            future.registerMessageHook(toDelete);
+
+            future.registerMessageHook((msg) => {
+              if (calls.length > 0) {
+                // delete the hook the second time around
+                future.removeMessageHook(toDelete);
+              }
+              calls.push('first');
+              return true;
+            });
+
+            future.onIOPub = () => {
+              calls.push('iopub')
+            };
+
+            future.onDone = () => {
+              expect(calls).to.eql([ 'first', 'delete', 'iopub', 'first', 'iopub' ]);
+              doLater(() => {
+                done();
+              });
+            };
+          });
+        });
+      });
+    });
   });
 
   describe('KernelManager', () => {

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -1478,6 +1478,7 @@ describe('jupyter.services - kernel', () => {
           });
         });
       });
+
     });
   });
 
@@ -1730,6 +1731,7 @@ describe('jupyter.services - kernel', () => {
           });
         });
       });
+
     });
   });
 


### PR DESCRIPTION
The IOPub hook system allows you to preempt the handlers for IOPub messages with a
given parent_header message id. 
* The most recently registered hook is run first.
* If the hook returns false, any later hooks and the future's onIOPub handler will not run.
* If a hook throws an error, the error is logged to the console and the next hook is run.
* If a hook is registered during the hook processing, it won't run until the next message.
* If a hook is disposed during the hook processing, it will be deactivated immediately.