### PR TITLE
Unify the library name and export the amd name

### DIFF
--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -16,7 +16,7 @@ else
     # Install the development version of the notebook
     git clone https://github.com/jupyter/notebook
     cd notebook
-    pip install --pre -e .
+    pip install --pre -v -e .
 fi
 
 # Create jupyter base dir (needed for config retrieval).

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,5 +9,6 @@ module.exports = {
         umdNamedDefine: true,
         publicPath: 'https://npmcdn.com/jupyter-js-services@' + version + '/dist/'
     },
+    bail: true,
     devtool: 'source-map'
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,9 @@ module.exports = {
     entry: './lib',
     output: {
         filename: './dist/index.js',
-        library: ['jupyter', 'services'],
+        library: 'jupyter-js-services',
         libraryTarget: 'umd',
+        umdNamedDefine: true,
         publicPath: 'https://npmcdn.com/jupyter-js-services@' + version + '/dist/'
     },
     devtool: 'source-map'


### PR DESCRIPTION
The header becomes:

```javascript
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define("jupyter-js-services", [], factory);
	else if(typeof exports === 'object')
		exports["jupyter-js-services"] = factory();
	else
		root["jupyter-js-services"] = factory();
})(this, function() {
```