### PR TITLE
Strip authorization info from websocket url console log

### DIFF
--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -907,7 +907,9 @@ class Kernel implements IKernel {
   private _createSocket(): void {
     let partialUrl = utils.urlPathJoin(this._wsUrl, KERNEL_SERVICE_URL,
                                        utils.urlJoinEncode(this._id));
-    console.log('Starting WebSocket:', partialUrl);
+    // Strip any authentication from the display string.
+    let display = partialUrl.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
+    console.log('Starting WebSocket:', display);
 
     let url = (
       utils.urlPathJoin(partialUrl, 'channels') +


### PR DESCRIPTION
Fixes #158.

cc @parente, I couldn't see any other places that would warrant this transform.