### PR TITLE
Add cwd to the contents manager

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -49,16 +49,6 @@ interface IServiceManager extends IDisposable {
   specsChanged: ISignal<IServiceManager, IKernel.ISpecModels>;
 
   /**
-   * A signal emitted when the cwd of the manager changes.
-   */
-  cwdChanged: ISignal<IServiceManager, string>;
-
-  /**
-   * The cwd of the manager.
-   */
-  cwd: string;
-
-  /**
    * The kernel specs for the manager.
    *
    * #### Notes
@@ -124,13 +114,6 @@ namespace IServiceManager {
      * The kernelspecs for the manager.
      */
     kernelspecs?: IKernel.ISpecModels;
-
-    /**
-     * The optional initial cwd of the manager.
-     *
-     * Defaults to an empty string.
-     */
-    cwd?: string;
   }
 }
 
@@ -168,7 +151,6 @@ class ServiceManager implements IServiceManager {
       baseUrl: options.baseUrl,
       ajaxSettings: options.ajaxSettings
     };
-    this._cwd = options.cwd || '';
     this._kernelspecs = options.kernelspecs;
     this._kernelManager = new KernelManager(subOptions);
     this._sessionManager = new SessionManager(subOptions);
@@ -186,28 +168,7 @@ class ServiceManager implements IServiceManager {
   }
 
   /**
-   * A signal emitted when the cwd of the manager changes.
-   */
-  get cwdChanged(): ISignal<IServiceManager, string> {
-    return Private.cwdChangedSignal.bind(this);
-  }
-
-  /**
-   * The cwd of the manager.
-   */
-  get cwd(): string {
-    return this._cwd;
-  }
-  set cwd(value: string) {
-    if (value === this._cwd) {
-      return;
-    }
-    this._cwd = value;
-    this.cwdChanged.emit(value);
-  }
-
-  /**
-   * Test whether the terminal manager is disposed.
+   * Test whether the service manager is disposed.
    *
    * #### Notes
    * This is a read-only property.

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -49,6 +49,16 @@ interface IServiceManager extends IDisposable {
   specsChanged: ISignal<IServiceManager, IKernel.ISpecModels>;
 
   /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  cwdChanged: ISignal<IServiceManager, string>;
+
+  /**
+   * The cwd of the manager.
+   */
+  cwd: string;
+
+  /**
    * The kernel specs for the manager.
    *
    * #### Notes
@@ -114,6 +124,13 @@ namespace IServiceManager {
      * The kernelspecs for the manager.
      */
     kernelspecs?: IKernel.ISpecModels;
+
+    /**
+     * The optional initial cwd of the manager.
+     *
+     * Defaults to an empty string.
+     */
+    cwd?: string;
   }
 }
 
@@ -151,6 +168,7 @@ class ServiceManager implements IServiceManager {
       baseUrl: options.baseUrl,
       ajaxSettings: options.ajaxSettings
     };
+    this._cwd = options.cwd || '';
     this._kernelspecs = options.kernelspecs;
     this._kernelManager = new KernelManager(subOptions);
     this._sessionManager = new SessionManager(subOptions);
@@ -165,6 +183,27 @@ class ServiceManager implements IServiceManager {
    */
   get specsChanged(): ISignal<ServiceManager, IKernel.ISpecModels> {
     return Private.specsChangedSignal.bind(this);
+  }
+
+  /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  get cwdChanged(): ISignal<IServiceManager, string> {
+    return Private.cwdChangedSignal.bind(this);
+  }
+
+  /**
+   * The cwd of the manager.
+   */
+  get cwd(): string {
+    return this._cwd;
+  }
+  set cwd(value: string) {
+    if (value === this._cwd) {
+      return;
+    }
+    this._cwd = value;
+    this.cwdChanged.emit(value);
   }
 
   /**
@@ -248,6 +287,7 @@ class ServiceManager implements IServiceManager {
   private _contentsManager: ContentsManager = null;
   private _terminalManager: TerminalManager = null;
   private _kernelspecs: IKernel.ISpecModels = null;
+  private _cwd = '';
   private _isDisposed = false;
 }
 
@@ -262,4 +302,10 @@ namespace Private {
    */
   export
   const specsChangedSignal = new Signal<IServiceManager, IKernel.ISpecModels>();
+
+  /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  export
+  const cwdChangedSignal = new Signal<IServiceManager, string>();
 }

--- a/src/mockcontents.ts
+++ b/src/mockcontents.ts
@@ -3,6 +3,10 @@
 'use strict';
 
 import {
+  ISignal, Signal, clearSignalData
+} from 'phosphor-signaling';
+
+import {
   IAjaxSettings
 } from './utils';
 
@@ -32,6 +36,48 @@ class MockContentsManager implements IContents.IManager {
   }
 
   /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  get cwdChanged(): ISignal<MockContentsManager, string> {
+    return Private.cwdChangedSignal.bind(this);
+  }
+
+  /**
+   * The cwd of the manager.
+   */
+  get cwd(): string {
+    return this._cwd;
+  }
+  set cwd(value: string) {
+    if (value === this._cwd) {
+      return;
+    }
+    this._cwd = value;
+    this.cwdChanged.emit(value);
+  }
+
+  /**
+   * Test whether the terminal manager is disposed.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Dispose of the resources used by the manager.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    clearSignalData(this);
+  }
+
+  /**
    * Get a path in the format it was saved or created in.
    */
   get(path: string, options: IContents.IFetchOptions = {}): Promise<IContents.IModel> {
@@ -49,6 +95,11 @@ class MockContentsManager implements IContents.IManager {
   getDownloadUrl(path: string): string {
     // no-op
     return path;
+  }
+
+  getAbsolutePath(relativePath: string, cwd?: string): string {
+    // no-op
+    return relativePath;
   }
 
   newUntitled(options: IContents.ICreateOptions = {}): Promise<IContents.IModel> {
@@ -155,4 +206,18 @@ class MockContentsManager implements IContents.IManager {
   private _checkpoints: { [key: string]: IContents.ICheckpointModel[] } = Object.create(null);
   private _fileSnaps: { [key: string]: IContents.IModel } = Object.create(null);
   private _id = 0;
+  private _isDisposed = false;
+  private _cwd = '';
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  export
+  const cwdChangedSignal = new Signal<MockContentsManager, string>();
 }

--- a/src/mockmanager.ts
+++ b/src/mockmanager.ts
@@ -54,6 +54,27 @@ class MockServiceManager implements IServiceManager {
   }
 
   /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  get cwdChanged(): ISignal<MockServiceManager, string> {
+    return Private.cwdChangedSignal.bind(this);
+  }
+
+  /**
+   * The cwd of the manager.
+   */
+  get cwd(): string {
+    return this._cwd;
+  }
+  set cwd(value: string) {
+    if (value === this._cwd) {
+      return;
+    }
+    this._cwd = value;
+    this.cwdChanged.emit(value);
+  }
+
+  /**
    * Test whether the terminal manager is disposed.
    *
    * #### Notes
@@ -126,6 +147,7 @@ class MockServiceManager implements IServiceManager {
   private _contentsManager: MockContentsManager = null;
   private _terminalManager: MockTerminalManager = null;
   private _kernelspecs: IKernel.ISpecModels = null;
+  private _cwd = '';
   private _isDisposed = false;
 }
 
@@ -140,4 +162,10 @@ namespace Private {
    */
   export
   const specsChangedSignal = new Signal<MockServiceManager, IKernel.ISpecModels>();
+
+  /**
+   * A signal emitted when the cwd of the manager changes.
+   */
+  export
+  const cwdChangedSignal = new Signal<MockServiceManager, string>();
 }

--- a/src/mockmanager.ts
+++ b/src/mockmanager.ts
@@ -54,27 +54,6 @@ class MockServiceManager implements IServiceManager {
   }
 
   /**
-   * A signal emitted when the cwd of the manager changes.
-   */
-  get cwdChanged(): ISignal<MockServiceManager, string> {
-    return Private.cwdChangedSignal.bind(this);
-  }
-
-  /**
-   * The cwd of the manager.
-   */
-  get cwd(): string {
-    return this._cwd;
-  }
-  set cwd(value: string) {
-    if (value === this._cwd) {
-      return;
-    }
-    this._cwd = value;
-    this.cwdChanged.emit(value);
-  }
-
-  /**
    * Test whether the terminal manager is disposed.
    *
    * #### Notes

--- a/test/src/testcontents.ts
+++ b/test/src/testcontents.ts
@@ -43,9 +43,73 @@ describe('jupyter.services - Contents', () => {
     it('should accept options', () => {
       let contents = new ContentsManager({
         baseUrl: 'foo',
-        ajaxSettings: {}
+        ajaxSettings: {},
+        cwd: 'foo/bar'
       });
       expect(contents).to.be.a(ContentsManager);
+      expect(contents.cwd).to.be('foo/bar');
+    });
+
+  });
+
+  describe('#cwdChanged', () => {
+
+    it('should be emitted when the cwd changes', (done) => {
+      let manager = new ContentsManager();
+      manager.cwdChanged.connect((sender, args) => {
+        expect(sender).to.be(manager);
+        expect(args).to.be('foo/bar');
+        done();
+      });
+      manager.cwd = 'foo/bar';
+    });
+
+  });
+
+  describe('#cwd', () => {
+
+    it('should default to an empty string', () => {
+      let manager = new ContentsManager();
+      expect(manager.cwd).to.be('');
+    });
+
+    it('should be settable', () => {
+      let manager = new ContentsManager();
+      manager.cwd = 'foo/bar';
+      expect(manager.cwd).to.be('foo/bar');
+    });
+
+  });
+
+  context('#isDisposed', () => {
+
+    it('should test whether the manager is disposed', () => {
+      let manager = new ContentsManager();
+      expect(manager.isDisposed).to.be(false);
+      manager.dispose();
+      expect(manager.isDisposed).to.be(true);
+    });
+
+    it('should be read-only', () => {
+      let manager = new ContentsManager();
+      expect(() => { manager.isDisposed = true; }).to.throwError();
+    });
+
+  });
+
+  context('#dispose()', () => {
+
+    it('should dispose of the resources held by the manager', () => {
+      let manager = new ContentsManager();
+      manager.dispose();
+      expect(manager.isDisposed).to.be(true);
+    });
+
+    it('should be safe to call multiple times', () => {
+      let manager = new ContentsManager();
+      manager.dispose();
+      manager.dispose();
+      expect(manager.isDisposed).to.be(true);
     });
 
   });
@@ -102,55 +166,65 @@ describe('jupyter.services - Contents', () => {
 
   });
 
-  describe('.getAbsolutePath()', () => {
+  describe('#getAbsolutePath()', () => {
 
     it('should get a file in the base directory', () => {
-      let path = ContentsManager.getAbsolutePath('bar.txt');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('bar.txt');
       expect(path).to.be('bar.txt');
     });
 
     it('should handle a relative path within the path', () => {
-      let url = ContentsManager.getAbsolutePath('fizz/../bar.txt');
-      expect(url).to.be('bar.txt');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('fizz/../bar.txt');
+      expect(path).to.be('bar.txt');
     });
 
     it('should get a file in the current directory', () => {
-      let path = ContentsManager.getAbsolutePath('./bar.txt', 'baz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('./bar.txt', 'baz');
       expect(path).to.be('baz/bar.txt');
     });
 
     it('should get a file in the parent directory', () => {
-      let path = ContentsManager.getAbsolutePath('../bar.txt', '/fizz/buzz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('../bar.txt', '/fizz/buzz');
       expect(path).to.be('fizz/bar.txt');
     });
 
     it('should get a file in the grandparent directory', () => {
-      let path = ContentsManager.getAbsolutePath('../../bar.txt', 'fizz/buzz/bing/');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('../../bar.txt', 'fizz/buzz/bing/');
       expect(path).to.be('fizz/bar.txt');
     });
 
     it('should return `null` if not contained in the base url', () => {
-      let path = ContentsManager.getAbsolutePath('../../bar.txt', 'fizz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('../../bar.txt', 'fizz');
       expect(path).to.be(null);
     });
 
     it('should short-circuit to the root directory of the server', () => {
-      let path = ContentsManager.getAbsolutePath('/bar.txt', 'fizz/buzz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('/bar.txt', 'fizz/buzz');
       expect(path).to.be('bar.txt');
     });
 
     it('should yield the current directory', () => {
-      let path = ContentsManager.getAbsolutePath('.', 'fizz/buzz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('.', 'fizz/buzz');
       expect(path).to.be('fizz/buzz');
     });
 
     it('should yield the parent directory', () => {
-      let path = ContentsManager.getAbsolutePath('..', 'fizz/buzz');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('..', 'fizz/buzz');
       expect(path).to.be('fizz');
     });
 
     it('should not encode characters ', () => {
-      let path = ContentsManager.getAbsolutePath('foo/b ar?.txt');
+      let manager = new ContentsManager();
+      let path = manager.getAbsolutePath('foo/b ar?.txt');
       expect(path).to.be('foo/b ar?.txt');
     });
 

--- a/test/src/testmanager.ts
+++ b/test/src/testmanager.ts
@@ -56,11 +56,9 @@ describe('manager', () => {
         baseUrl: 'foo',
         ajaxSettings: {},
         kernelspecs: KERNELSPECS,
-        cwd: 'foo/bar'
       };
       createServiceManager(options).then(manager => {
         expect(manager.kernels).to.be.a(KernelManager);
-        expect(manager.cwd).to.be('foo/bar');
         done();
       }).catch(done);
     });
@@ -81,6 +79,35 @@ describe('manager', () => {
       });
     });
 
+    describe('#isDisposed', () => {
+
+      it('should test whether the manager is disposed', () => {
+        expect(manager.isDisposed).to.be(false);
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+      });
+
+      it('should be read-only', () => {
+        expect(() => { manager.isDisposed = true; }).to.throwError();
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the resources held by the manager', () => {
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+      });
+
+      it('should be safe to call multiple times', () => {
+        manager.dispose();
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+      });
+
+    });
+
     describe('#specsChanged', () => {
 
       it('should be emitted when the specs change', (done) => {
@@ -93,32 +120,6 @@ describe('manager', () => {
           handler.respond(200, KERNELSPECS);
         });
         manager.kernels.getSpecs();
-      });
-
-    });
-
-    describe('#cwdChanged', () => {
-
-      it('should be emitted when the cwd changes', (done) => {
-        manager.cwdChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
-          expect(args).to.be('foo/bar');
-          done();
-        });
-        manager.cwd = 'foo/bar';
-      });
-
-    });
-
-    describe('#cwd', () => {
-
-      it('should default to an empty string', () => {
-        expect(manager.cwd).to.be('');
-      });
-
-      it('should be settable', () => {
-        manager.cwd = 'foo/bar';
-        expect(manager.cwd).to.be('foo/bar');
       });
 
     });

--- a/test/src/testmanager.ts
+++ b/test/src/testmanager.ts
@@ -55,10 +55,12 @@ describe('manager', () => {
       let options = {
         baseUrl: 'foo',
         ajaxSettings: {},
-        kernelspecs: KERNELSPECS
+        kernelspecs: KERNELSPECS,
+        cwd: 'foo/bar'
       };
       createServiceManager(options).then(manager => {
         expect(manager.kernels).to.be.a(KernelManager);
+        expect(manager.cwd).to.be('foo/bar');
         done();
       }).catch(done);
     });
@@ -91,6 +93,32 @@ describe('manager', () => {
           handler.respond(200, KERNELSPECS);
         });
         manager.kernels.getSpecs();
+      });
+
+    });
+
+    describe('#cwdChanged', () => {
+
+      it('should be emitted when the cwd changes', (done) => {
+        manager.cwdChanged.connect((sender, args) => {
+          expect(sender).to.be(manager);
+          expect(args).to.be('foo/bar');
+          done();
+        });
+        manager.cwd = 'foo/bar';
+      });
+
+    });
+
+    describe('#cwd', () => {
+
+      it('should default to an empty string', () => {
+        expect(manager.cwd).to.be('');
+      });
+
+      it('should be settable', () => {
+        manager.cwd = 'foo/bar';
+        expect(manager.cwd).to.be('foo/bar');
       });
 
     });


### PR DESCRIPTION
cf https://github.com/jupyter/jupyterlab/issues/446

This provides a common `cwd` to all consumers of a contents manager.
This will replace the `PathTracker` in the application.