### PR TITLE
Add a file extension normalization function and expose url.parse

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -708,6 +708,11 @@ namespace ContentsManager {
    */
   export
   function getAbsolutePath(relativePath: string, cwd = ''): string {
+    // Bail if it looks like a url.
+    let urlObj = utils.urlParse(relativePath);
+    if (urlObj.protocol) {
+      return relativePath;
+    }
     let norm = posix.normalize(posix.join(cwd, relativePath));
     if (norm.indexOf('../') === 0) {
       return null;
@@ -753,7 +758,7 @@ namespace ContentsManager {
    */
   export
   function normalizeExtension(extension: string): string {
-    if (extension.indexOf('.') !== 0) {
+    if (extension.length > 0 && extension.indexOf('.') !== 0) {
       extension = `.${extension}`;
     }
     return extension.toLowerCase();

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -144,7 +144,7 @@ namespace IContents {
      path?: string;
 
      /**
-      * The optional file extension for the new file.
+      * The optional file extension for the new file (e.g. `".txt"`).
       *
       * #### Notes
       * This ignored if `type` is `'notebook'`.
@@ -401,6 +401,9 @@ class ContentsManager implements IContents.IManager {
     ajaxSettings.method = 'POST';
     ajaxSettings.dataType = 'json';
     if (options) {
+      if (options.ext) {
+        options.ext = ContentsManager.normalizeExtension(options.ext);
+      }
       ajaxSettings.data = JSON.stringify(options);
       ajaxSettings.contentType = 'application/json';
     }
@@ -741,5 +744,18 @@ namespace ContentsManager {
   export
   function extname(path: string): string {
     return posix.extname(path);
+  }
+
+  /**
+   * Normalize a file extension to be of the type `'.foo'`.
+   *
+   * Adds a leading dot if not present and converts to lower case.
+   */
+  export
+  function normalizeExtension(extension: string): string {
+    if (extension.indexOf('.') !== 0) {
+      extension = `.${extension}`;
+    }
+    return extension.toLowerCase();
   }
 }

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -980,7 +980,8 @@ class Kernel implements IKernel {
     let partialUrl = utils.urlPathJoin(this._wsUrl, KERNEL_SERVICE_URL,
                                        encodeURIComponent(this._id));
     // Strip any authentication from the display string.
-    let display = partialUrl.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
+    let parsed = utils.urlParse(partialUrl);
+    let display = partialUrl.replace(parsed.auth, '');
     console.log('Starting WebSocket:', display);
 
     let url = utils.urlPathJoin(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,6 +60,112 @@ function uuid(): string {
 
 
 /**
+ * An object describing a url.
+ */
+export
+interface IUrlObject {
+  /**
+   * The full URL string that was parsed with both the `protocol` and `host`
+   * components converted to lower-case.
+   */
+  href: string;
+
+  /**
+   * The URL's lower-cased protocol scheme.
+   */
+  protocol: string;
+
+  /**
+   * Whether two ASCII forward-slash characters `(/)` are required following
+   * the colon in the protocol.
+   */
+  slashes: boolean;
+
+  /**
+   * The full lower-cased host portion of the URL, including the `port` if
+   * specified.
+   */
+  host: string;
+
+  /**
+   * The username and password portion of the URL, also referred to as
+   * "userinfo". This string subset follows the `protocol` and double slashes
+   * (if present) and preceeds the host component, delimited by an ASCII "at
+   * sign" `(@)`. The format of the string is `{username}[:{password}]`, with
+   * the `[:{password}]` portion being optional.
+   */
+  auth: string;
+
+  /**
+   * The lower-cased host name portion of the `host` component *without* the
+   * port included.
+   */
+  hostname: string;
+
+  /**
+   * The numeric port portion of the `host` component.
+   */
+  port: string;
+
+  /**
+   * The entire path section of the URL. This is everything following the
+   * `host` (including the `port`) and before the start of the `query` or
+   * `hash` components, delimited by either the ASCII question mark `(?)` or
+   * hash `(#)` characters.
+   */
+  pathname: string;
+
+  /**
+   * The entire "query string" portion of the URL, including the leading ASCII
+   * question mark `(?)` character.
+   */
+  search: string;
+
+  /**
+   * A concatenation of the `pathname` and `search` components.
+   */
+  path: string;
+
+  /**
+   * Either the "params" portion of the `query` string ( everything except the
+   *  leading ASCII question mark `(?)`, or an object returned by the
+   *  `querystring` module's `parse()` method.
+   */
+  query: string;
+
+  /**
+   * The "fragment" portion of the URL including the leading ASCII hash
+   * `(#)` character.
+   */
+  hash: string;
+}
+
+
+/**
+ * Parse a url into a URL object.
+ *
+ * @param urlString - The URL string to parse.
+ *
+ * @param parseQueryString - If `true`, the query property will always be set
+ *   to an object returned by the `querystring` module's `parse()` method.
+ *   If `false`, the `query` property on the returned URL object will be an
+ *   unparsed, undecoded string. Defaults to `false`.
+ *
+ * @param slashedDenoteHost - If `true`, the first token after the literal
+ *   string `//` and preceeding the next `/` will be interpreted as the `host`.
+ *   For instance, given `//foo/bar`, the result would be
+ *   `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
+ *   Defaults to `false`.
+ *
+ * @returns A URL object.
+ */
+export
+function urlParse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): IUrlObject {
+  return url.parse(urlStr, parseQueryString, slashesDenoteHost);
+}
+
+
+/**
  * Resolve a url.
  *
  * Take a base URL, and a href URL, and resolve them as a browser would for

--- a/test/src/testcontents.ts
+++ b/test/src/testcontents.ts
@@ -154,6 +154,11 @@ describe('jupyter.services - Contents', () => {
       expect(path).to.be('foo/b ar?.txt');
     });
 
+    it('should bail on a url', () => {
+      let path = ContentsManager.getAbsolutePath('http://../foo.txt');
+      expect(path).to.be('http://../foo.txt');
+    });
+
   });
 
   describe('.normalizeExtension()', () => {
@@ -171,6 +176,11 @@ describe('jupyter.services - Contents', () => {
     it('should convert to lower case', () => {
       let ext = ContentsManager.normalizeExtension('.TXT');
       expect(ext).to.be('.txt');
+    });
+
+    it('should handle an empty extension', () => {
+      let ext = ContentsManager.normalizeExtension('');
+      expect(ext).to.be('');
     });
 
   });

--- a/test/src/testcontents.ts
+++ b/test/src/testcontents.ts
@@ -156,6 +156,25 @@ describe('jupyter.services - Contents', () => {
 
   });
 
+  describe('.normalizeExtension()', () => {
+
+    it('should add pass a valid extension through unmodified', () => {
+      let ext = ContentsManager.normalizeExtension('.txt');
+      expect(ext).to.be('.txt');
+    });
+
+    it('should add a leading dot if not present', () => {
+      let ext = ContentsManager.normalizeExtension('txt');
+      expect(ext).to.be('.txt');
+    });
+
+    it('should convert to lower case', () => {
+      let ext = ContentsManager.normalizeExtension('.TXT');
+      expect(ext).to.be('.txt');
+    });
+
+  });
+
   describe('#getDownloadUrl()', () => {
 
     it('should get the url of a file', () => {

--- a/typings/url/url.d.ts
+++ b/typings/url/url.d.ts
@@ -17,6 +17,7 @@ declare module 'url' {
   interface IUrlObject {
     href: string;
     protocol: string;
+    slashes: boolean;
     host: string;
     auth: string;
     hostname: string;


### PR DESCRIPTION
These will be used in JupyterLab in the document registry and manager.