### PR TITLE
Fix handling of request errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -143,7 +143,7 @@ class ConfigSection implements IConfigSection {
     ajaxSettings.cache = false;
     return utils.ajaxRequest(this._url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       this._data = success.data;
     });
@@ -171,7 +171,7 @@ class ConfigSection implements IConfigSection {
 
     return utils.ajaxRequest(this._url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+       return utils.makeAjaxError(success);
       }
 
       this._data = success.data;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -363,9 +363,13 @@ class ContentsManager implements IContents.IManager {
 
     return utils.ajaxRequest(url, ajaxSettings).then((success: utils.IAjaxSuccess): IContents.IModel => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateContentsModel(success.data);
+      try {
+         validate.validateContentsModel(success.data);
+       } catch (err) {
+         return utils.makeAjaxError(success, err.message);
+       }
       return success.data;
     });
   }
@@ -407,9 +411,13 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(options.path || '');
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 201) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateContentsModel(success.data);
+      try {
+        validate.validateContentsModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return success.data;
     });
   }
@@ -432,7 +440,7 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path);
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
     }, error => {
         // Translate certain errors to more specific ones.
@@ -441,10 +449,10 @@ class ContentsManager implements IContents.IManager {
         if (error.xhr.status === 400) {
           let err = JSON.parse(error.xhr.response);
           if (err.message) {
-            throw new Error(err.message);
+            error.throwError = err.message;
           }
         }
-        throw new Error(error.xhr.statusText);
+        return Promise.reject(error);
       }
     );
   }
@@ -472,9 +480,13 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path);
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateContentsModel(success.data);
+      try {
+        validate.validateContentsModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return success.data;
     });
   }
@@ -506,9 +518,13 @@ class ContentsManager implements IContents.IManager {
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       // will return 200 for an existing file and 201 for a new file
       if (success.xhr.status !== 200 && success.xhr.status !== 201) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateContentsModel(success.data);
+      try {
+        validate.validateContentsModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return success.data;
     });
   }
@@ -538,9 +554,13 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(toDir);
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 201) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateContentsModel(success.data);
+      try {
+        validate.validateContentsModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return success.data;
     });
   }
@@ -564,9 +584,13 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path, 'checkpoints');
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 201) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateCheckpointModel(success.data);
+      try {
+        validate.validateCheckpointModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return success.data;
     });
   }
@@ -591,13 +615,17 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path, 'checkpoints');
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       if (!Array.isArray(success.data)) {
-        throw Error('Invalid Checkpoint list');
+        return utils.makeAjaxError(success, 'Invalid Checkpoint list');
       }
       for (let i = 0; i < success.data.length; i++) {
+        try {
         validate.validateCheckpointModel(success.data[i]);
+        } catch (err) {
+          return utils.makeAjaxError(success, err.message);
+        }
       }
       return success.data;
     });
@@ -623,7 +651,7 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path, 'checkpoints', checkpointID);
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
     });
 
@@ -649,7 +677,7 @@ class ContentsManager implements IContents.IManager {
     let url = this._getUrl(path, 'checkpoints', checkpointID);
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
     });
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -897,7 +897,7 @@ namespace Private {
       if (rejected.xhr.status === 410) {
         throw Error('The kernel was deleted but the session was not');
       }
-      onSessionError(rejected);
+      return onSessionError(rejected);
     });
   }
 
@@ -913,12 +913,13 @@ namespace Private {
    * Handle an error on a session Ajax call.
    */
   export
-  function onSessionError(error: utils.IAjaxError): any {
-    let text = (error.statusText ||
-                error.error.message ||
+  function onSessionError(error: utils.IAjaxError): Promise<any> {
+    let text = (error.throwError ||
+                error.xhr.statusText ||
                 error.xhr.responseText);
-    let msg = `API request failed (${error.xhr.status}):  ${text}`;
-    throw Error(msg);
+    let msg = `API request failed: ${text}`;
+    console.error(msg);
+    return Promise.reject(error);
   }
 
   /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -206,13 +206,17 @@ function listRunningSessions(options?: ISession.IOptions): Promise<ISession.IMod
 
   return utils.ajaxRequest(url, ajaxSettings).then(success => {
     if (success.xhr.status !== 200) {
-      throw Error('Invalid Status: ' + success.xhr.status);
+      return utils.makeAjaxError(success);
     }
     if (!Array.isArray(success.data)) {
-      throw Error('Invalid Session list');
+      return utils.makeAjaxError(success, 'Invalid Session list');
     }
     for (let i = 0; i < success.data.length; i++) {
-      validate.validateSessionModel(success.data[i]);
+      try {
+        validate.validateSessionModel(success.data[i]);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
     }
     return Private.updateRunningSessions(success.data);
   }, Private.onSessionError);
@@ -676,12 +680,16 @@ class Session implements ISession {
     this._updating = true;
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
+      this._updating = false;
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       let data = success.data as ISession.IModel;
-      validate.validateSessionModel(data);
-      this._updating = false;
+      try {
+        validate.validateSessionModel(data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return Private.updateByModel(data);
     }, error => {
       this._updating = false;
@@ -779,9 +787,13 @@ namespace Private {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 201) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-      validate.validateSessionModel(success.data);
+      try {
+        validate.validateSessionModel(success.data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       let data = success.data as ISession.IModel;
       return updateByModel(data);
     }, onSessionError);
@@ -832,10 +844,14 @@ namespace Private {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       let data = success.data as ISession.IModel;
-      validate.validateSessionModel(data);
+      try {
+        validate.validateSessionModel(data);
+      } catch (err) {
+        return utils.makeAjaxError(success, err.message);
+      }
       return updateByModel(data);
     }, Private.onSessionError);
   }
@@ -891,13 +907,13 @@ namespace Private {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw Error('Invalid Status: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
-    }, rejected => {
-      if (rejected.xhr.status === 410) {
-        throw Error('The kernel was deleted but the session was not');
+    }, err => {
+      if (err.xhr.status === 410) {
+        err.throwError = 'The kernel was deleted but the session was not';
       }
-      return onSessionError(rejected);
+      return onSessionError(err);
     });
   }
 

--- a/src/terminals.ts
+++ b/src/terminals.ts
@@ -246,7 +246,7 @@ class TerminalManager implements ITerminalSession.IManager {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw new Error('Invalid Response: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
     });
   }
@@ -262,11 +262,11 @@ class TerminalManager implements ITerminalSession.IManager {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw new Error('Invalid Response: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       let data = success.data as ITerminalSession.IModel[];
       if (!Array.isArray(data)) {
-        throw new Error('Invalid terminal data');
+        return utils.makeAjaxError(success, 'Invalid terminal data');
       }
       if (!deepEqual(data, this._running)) {
         this._running = data.slice();
@@ -401,7 +401,7 @@ class TerminalSession implements ITerminalSession {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 204) {
-        throw new Error('Invalid Response: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       this.dispose();
     });
@@ -431,7 +431,7 @@ class TerminalSession implements ITerminalSession {
 
     return utils.ajaxRequest(url, ajaxSettings).then(success => {
       if (success.xhr.status !== 200) {
-        throw new Error('Invalid Response: ' + success.xhr.status);
+        return utils.makeAjaxError(success);
       }
       return (success.data as ITerminalSession.IModel).name;
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -266,7 +266,6 @@ function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuc
     xhr.onload = (event: ProgressEvent) => {
       if (xhr.status >= 400) {
         reject({ event, xhr, ajaxSettings, throwError: xhr.statusText });
-        return;
       }
       let data = xhr.responseText;
       if (ajaxSettings.dataType === 'json' && data) {
@@ -333,6 +332,24 @@ function loadObject(name: string, moduleName: string, registry?: { [key: string]
     }
   });
 };
+
+
+/**
+ * Create an ajax error from an ajax success.
+ *
+ * @param success - The original success object.
+ *
+ * @param throwError - The optional new error name.  If not given
+ *  we use "Invalid Status: <xhr.status>"
+ */
+export
+function makeAjaxError(success: IAjaxSuccess, throwError?: string): Promise<any> {
+  let xhr = success.xhr;
+  let ajaxSettings = success.ajaxSettings;
+  let event = success.event;
+  throwError = throwError || `Invalid Status: ${xhr.status}`;
+  return Promise.reject({ xhr, ajaxSettings, event, throwError });
+}
 
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -264,7 +264,7 @@ function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuc
     }
 
     xhr.onload = (event: ProgressEvent) => {
-      if (xhr.status >= 400) {
+      if (xhr.status >= 300) {
         reject({ event, xhr, ajaxSettings, throwError: xhr.statusText });
       }
       let data = xhr.responseText;
@@ -301,6 +301,24 @@ function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuc
 
 
 /**
+ * Create an ajax error from an ajax success.
+ *
+ * @param success - The original success object.
+ *
+ * @param throwError - The optional new error name.  If not given
+ *  we use "Invalid Status: <xhr.status>"
+ */
+export
+function makeAjaxError(success: IAjaxSuccess, throwError?: string): Promise<any> {
+  let xhr = success.xhr;
+  let ajaxSettings = success.ajaxSettings;
+  let event = success.event;
+  throwError = throwError || `Invalid Status: ${xhr.status}`;
+  return Promise.reject({ xhr, ajaxSettings, event, throwError });
+}
+
+
+/**
  * Try to load an object from a module or a registry.
  *
  * Try to load an object from a module asynchronously if a module
@@ -332,24 +350,6 @@ function loadObject(name: string, moduleName: string, registry?: { [key: string]
     }
   });
 };
-
-
-/**
- * Create an ajax error from an ajax success.
- *
- * @param success - The original success object.
- *
- * @param throwError - The optional new error name.  If not given
- *  we use "Invalid Status: <xhr.status>"
- */
-export
-function makeAjaxError(success: IAjaxSuccess, throwError?: string): Promise<any> {
-  let xhr = success.xhr;
-  let ajaxSettings = success.ajaxSettings;
-  let event = success.event;
-  throwError = throwError || `Invalid Status: ${xhr.status}`;
-  return Promise.reject({ xhr, ajaxSettings, event, throwError });
-}
 
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,46 +171,56 @@ interface IAjaxSettings extends JSONObject {
 
 
 /**
- * Success handler for AJAX request.
+ * Data for a successful  AJAX request.
  */
 export
 interface IAjaxSuccess {
   /**
-   * The data returned by the ajax call.
+   * The `onload` event.
    */
-  data: any;
-
-  /**
-   * The status text of the response.
-   */
-  statusText: string;
+  event: ProgressEvent;
 
   /**
    * The XHR object.
    */
   xhr: XMLHttpRequest;
+
+  /**
+   * The ajax settings associated with the request.
+   */
+  ajaxSettings: IAjaxSettings;
+
+  /**
+   * The data returned by the ajax call.
+   */
+  data: any;
 }
 
 
 /**
- * Error handler for AJAX request.
+ * Data for an unsuccesful AJAX request.
  */
 export
 interface IAjaxError {
+  /**
+   * The event triggering the error.
+   */
+  event: Event;
+
   /**
    * The XHR object.
    */
   xhr: XMLHttpRequest;
 
   /**
-   * The status text of the response.
+   * The ajax settings associated with the request.
    */
-  statusText: string;
+  ajaxSettings: IAjaxSettings;
 
   /**
-   * The response error object.
+   * The error message, if `onerror`.
    */
-  error: ErrorEvent;
+  throwError?: string;
 }
 
 
@@ -225,60 +235,67 @@ interface IAjaxError {
  * Based on this [example](http://www.html5rocks.com/en/tutorials/es6/promises/#toc-promisifying-xmlhttprequest).
  */
 export
-function ajaxRequest(url: string, settings: IAjaxSettings): Promise<IAjaxSuccess> {
-  let method = settings.method || 'GET';
-  let user = settings.user || '';
-  let password = settings.password || '';
-  if (!settings.cache) {
+function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuccess> {
+  let method = ajaxSettings.method || 'GET';
+  let user = ajaxSettings.user || '';
+  let password = ajaxSettings.password || '';
+  if (!ajaxSettings.cache) {
     // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache.
     url += ((/\?/).test(url) ? '&' : '?') + (new Date()).getTime();
   }
 
   return new Promise((resolve, reject) => {
-    let req = new XMLHttpRequest();
-    req.open(method, url, true, user, password);
+    let xhr = new XMLHttpRequest();
+    xhr.open(method, url, true, user, password);
 
-    if (settings.contentType !== void 0) {
-      req.setRequestHeader('Content-Type', settings.contentType);
+    if (ajaxSettings.contentType !== void 0) {
+      xhr.setRequestHeader('Content-Type', ajaxSettings.contentType);
     }
-    if (settings.timeout !== void 0) {
-      req.timeout = settings.timeout;
+    if (ajaxSettings.timeout !== void 0) {
+      xhr.timeout = ajaxSettings.timeout;
     }
-    if (!!settings.withCredentials) {
-      req.withCredentials = true;
+    if (!!ajaxSettings.withCredentials) {
+      xhr.withCredentials = true;
     }
-    if (settings.requestHeaders !== void 0) {
-       for (let prop in settings.requestHeaders) {
-         req.setRequestHeader(prop, (settings as any).requestHeaders[prop]);
+    if (ajaxSettings.requestHeaders !== void 0) {
+       for (let prop in ajaxSettings.requestHeaders) {
+         xhr.setRequestHeader(prop, ajaxSettings.requestHeaders[prop]);
        }
     }
 
-    req.onload = () => {
-      if (req.status >= 400) {
-        let error = new Error(req.statusText);
-        reject({ xhr: req, statusText: req.statusText, error: error });
+    xhr.onload = (event: ProgressEvent) => {
+      if (xhr.status >= 400) {
+        reject({ event, xhr, ajaxSettings, throwError: xhr.statusText });
         return;
       }
-      let response = req.responseText;
-      if (settings.dataType === 'json' && response) {
-        response = JSON.parse(response);
+      let data = xhr.responseText;
+      if (ajaxSettings.dataType === 'json' && data) {
+        try {
+          data = JSON.parse(data);
+        } catch (err) {
+          let throwError = err.message;
+          reject({ event, xhr, ajaxSettings, throwError });
+        }
       }
-      resolve({ data: response, statusText: req.statusText, xhr: req });
+      resolve({ xhr, ajaxSettings, data, event });
     };
 
-    req.onerror = (err: ErrorEvent) => {
-      reject({ xhr: req, statusText: req.statusText, error: err });
+    xhr.onabort = (event: Event) => {
+      reject({ xhr, event, ajaxSettings });
     };
 
-    req.ontimeout = () => {
-      reject({ xhr: req, statusText: req.statusText,
-               error: new Error('Operation Timed Out') });
+    xhr.onerror = (event: ErrorEvent) => {
+      reject({ xhr, event, ajaxSettings });
     };
 
-    if (settings.data) {
-      req.send(settings.data);
+    xhr.ontimeout = (ev: ProgressEvent) => {
+      reject({ xhr, event, ajaxSettings });
+    };
+
+    if (ajaxSettings.data) {
+      xhr.send(ajaxSettings.data);
     } else {
-      req.send();
+      xhr.send();
     }
   });
 }

--- a/test/src/testconfig.ts
+++ b/test/src/testconfig.ts
@@ -13,11 +13,11 @@ import {
 } from '../../lib/json';
 
 import {
-  RequestHandler, ajaxSettings, expectFailure
+  RequestHandler, ajaxSettings, expectFailure, expectAjaxError
 } from './utils';
 
 
-describe('jupyter.services - IConfigSection', () => {
+describe('config', () => {
 
   describe('getConfigSection()', () => {
 
@@ -54,7 +54,7 @@ describe('jupyter.services - IConfigSection', () => {
         handler.respond(201, { });
       });
       let configPromise = getConfigSection({ name: 'test' });
-      expectFailure(configPromise, done, 'Invalid Status: 201');
+      expectAjaxError(configPromise, done, 'Invalid Status: 201');
     });
 
   });
@@ -105,7 +105,7 @@ describe('jupyter.services - IConfigSection', () => {
           handler.respond(201, { });
         };
         let update = config.update({ foo: 'baz' });
-        expectFailure(update, done, 'Invalid Status: 201');
+        expectAjaxError(update, done, 'Invalid Status: 201');
       });
     });
 
@@ -229,7 +229,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
         let config = new ConfigWithDefaults({ section });
         let set = config.set('foo', 'bar');
         expect(section.data['foo']).to.be('bar');
-        expectFailure(set, done, 'Invalid Status: 201');
+        expectAjaxError(set, done, 'Invalid Status: 201');
       });
 
     });

--- a/test/src/testcontents.ts
+++ b/test/src/testcontents.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/contents';
 
 import {
-  DEFAULT_FILE, RequestHandler, ajaxSettings, expectFailure
+  DEFAULT_FILE, RequestHandler, ajaxSettings, expectFailure, expectAjaxError
 } from './utils';
 
 
@@ -31,7 +31,7 @@ let DEFAULT_CP: IContents.ICheckpointModel = {
 };
 
 
-describe('jupyter.services - Contents', () => {
+describe('contents', () => {
 
   describe('#constructor()', () => {
 
@@ -97,7 +97,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(201, DEFAULT_DIR);
       });
       let get = contents.get('/foo');
-      expectFailure(get, done, 'Invalid Status: 201');
+      expectAjaxError(get, done, 'Invalid Status: 201');
     });
 
   });
@@ -249,7 +249,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(200, DEFAULT_DIR);
       });
       let newDir = contents.newUntitled();
-      expectFailure(newDir, done, 'Invalid Status: 200');
+      expectAjaxError(newDir, done, 'Invalid Status: 200');
     });
 
   });
@@ -282,7 +282,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(200, { });
       });
       let del = contents.delete('/foo/bar.txt');
-      expectFailure(del, done, 'Invalid Status: 200');
+      expectAjaxError(del, done, 'Invalid Status: 200');
     });
 
     it('should throw a specific error', (done) => {
@@ -348,7 +348,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(201, DEFAULT_FILE);
       });
       let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
-      expectFailure(rename, done, 'Invalid Status: 201');
+      expectAjaxError(rename, done, 'Invalid Status: 201');
     });
 
   });
@@ -408,7 +408,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(204, DEFAULT_FILE);
       });
       let save = contents.save('/foo', { type: 'file', name: 'test' });
-      expectFailure(save, done, 'Invalid Status: 204');
+      expectAjaxError(save, done, 'Invalid Status: 204');
     });
 
   });
@@ -454,7 +454,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(200, DEFAULT_FILE);
       });
       let copy = contents.copy('/foo/bar.txt', '/baz');
-      expectFailure(copy, done, 'Invalid Status: 200');
+      expectAjaxError(copy, done, 'Invalid Status: 200');
     });
 
   });
@@ -502,7 +502,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(200, DEFAULT_CP);
       });
       let checkpoint = contents.createCheckpoint('/foo/bar.txt');
-      expectFailure(checkpoint, done, 'Invalid Status: 200');
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
     });
 
   });
@@ -546,7 +546,7 @@ describe('jupyter.services - Contents', () => {
           handler.respond(200, DEFAULT_CP);
         };
         let newCheckpoints = contents.listCheckpoints('/foo/bar.txt');
-        expectFailure(newCheckpoints, done, 'Invalid Checkpoint list');
+        expectAjaxError(newCheckpoints, done, 'Invalid Checkpoint list');
       };
 
       expectFailure(checkpoints, second);
@@ -558,7 +558,7 @@ describe('jupyter.services - Contents', () => {
         handler.respond(201, { });
       });
       let checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      expectFailure(checkpoints, done, 'Invalid Status: 201');
+      expectAjaxError(checkpoints, done, 'Invalid Status: 201');
     });
 
   });
@@ -596,7 +596,7 @@ describe('jupyter.services - Contents', () => {
       });
       let checkpoint = contents.restoreCheckpoint('/foo/bar.txt',
                                                   DEFAULT_CP.id);
-      expectFailure(checkpoint, done, 'Invalid Status: 200');
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
     });
 
   });
@@ -628,7 +628,7 @@ describe('jupyter.services - Contents', () => {
       });
       let checkpoint = contents.deleteCheckpoint('/foo/bar.txt',
                                                   DEFAULT_CP.id);
-      expectFailure(checkpoint, done, 'Invalid Status: 200');
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
     });
 
   });

--- a/test/src/testkernel.ts
+++ b/test/src/testkernel.ts
@@ -5,7 +5,7 @@
 import expect = require('expect.js');
 
 import {
-  uuid
+  uuid, IAjaxError
 } from '../../lib/utils';
 
 import {
@@ -26,8 +26,9 @@ import {
 } from '../../lib/json';
 
 import {
-  RequestHandler, ajaxSettings, doLater, expectFailure, createKernel,
-  KernelTester, KERNEL_OPTIONS, AJAX_KERNEL_OPTIONS, EXAMPLE_KERNEL_INFO,
+  RequestHandler, ajaxSettings, doLater, expectFailure, expectAjaxError,
+  createKernel, KernelTester,
+  KERNEL_OPTIONS, AJAX_KERNEL_OPTIONS, EXAMPLE_KERNEL_INFO,
   PYTHON_SPEC
 } from './utils';
 
@@ -49,7 +50,7 @@ let createMsg = (channel: KernelMessage.Channel, parent_header: JSONObject): Ker
 };
 
 
-describe('jupyter.services - kernel', () => {
+describe('kernel', () => {
 
   describe('listRunningKernels()', () => {
 
@@ -95,8 +96,8 @@ describe('jupyter.services - kernel', () => {
         let data = { id: uuid(), name: 'test' };
         handler.respond(200, data);
       });
-      let list = listRunningKernels({ baseUrl: 'http://localhost:8888' });
-      expectFailure(list, done, 'Invalid kernel list');
+      let promise = listRunningKernels({ baseUrl: 'http://localhost:8888' });
+      expectAjaxError(promise, done, 'Invalid kernel list');
     });
 
     it('should throw an error for an invalid response', (done) => {
@@ -104,7 +105,7 @@ describe('jupyter.services - kernel', () => {
         handler.respond(201, { });
       });
       let list = listRunningKernels({ baseUrl: 'http://localhost:8888' });
-      expectFailure(list, done, 'Invalid Status: 201');
+      expectAjaxError(list, done, 'Invalid Status: 201');
     });
 
     it('should throw an error for an error response', (done) => {
@@ -178,7 +179,7 @@ describe('jupyter.services - kernel', () => {
         tester.respond(200, data);
       });
       let kernelPromise = startNewKernel(KERNEL_OPTIONS);
-      expectFailure(kernelPromise, done, 'Invalid Status: 200');
+      expectAjaxError(kernelPromise, done, 'Invalid Status: 200');
     });
 
     it('should throw an error for an error response', (done) => {
@@ -744,7 +745,7 @@ describe('jupyter.services - kernel', () => {
             tester.respond(200,  { id: kernel.id, name: kernel.name });
           };
           let interrupt = kernel.interrupt();
-          expectFailure(interrupt, done, 'Invalid Status: 200');
+          expectAjaxError(interrupt, done, 'Invalid Status: 200');
         });
       });
 
@@ -814,7 +815,7 @@ describe('jupyter.services - kernel', () => {
             tester.respond(204, { id: kernel.id, name: kernel.name });
           };
           let restart = kernel.restart();
-          expectFailure(restart, done, 'Invalid Status: 204');
+          expectAjaxError(restart, done, 'Invalid Status: 204');
         });
       });
 
@@ -913,7 +914,7 @@ describe('jupyter.services - kernel', () => {
             tester.respond(200, { id: uuid(), name: KERNEL_OPTIONS.name });
           };
           let shutdown = kernel.shutdown();
-          expectFailure(shutdown, done, 'Invalid Status: 200');
+          expectAjaxError(shutdown, done, 'Invalid Status: 200');
         });
       });
 
@@ -2001,7 +2002,7 @@ describe('jupyter.services - kernel', () => {
         handler.respond(200, { 'default': PYTHON_SPEC.name });
       };
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No kernelspecs found');
+      expectAjaxError(promise, done, 'No kernelspecs found');
     });
 
     it('should omit an invalid kernelspec', (done) => {
@@ -2027,7 +2028,7 @@ describe('jupyter.services - kernel', () => {
                                'kernelspecs': { 'R': R_SPEC } });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No valid kernelspecs found');
+      expectAjaxError(promise, done, 'No valid kernelspecs found');
     });
 
     it('should handle an improper language', (done) => {
@@ -2038,7 +2039,7 @@ describe('jupyter.services - kernel', () => {
                              'kernelspecs': { 'R': R_SPEC } });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No valid kernelspecs found');
+      expectAjaxError(promise, done, 'No valid kernelspecs found');
     });
 
     it('should handle an improper argv', (done) => {
@@ -2049,7 +2050,7 @@ describe('jupyter.services - kernel', () => {
                                'kernelspecs': { 'R': R_SPEC } });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No valid kernelspecs found');
+      expectAjaxError(promise, done, 'No valid kernelspecs found');
     });
 
     it('should handle an improper display_name', (done) => {
@@ -2060,7 +2061,7 @@ describe('jupyter.services - kernel', () => {
                                'kernelspecs': { 'R': R_SPEC } });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No valid kernelspecs found');
+      expectAjaxError(promise, done, 'No valid kernelspecs found');
     });
 
     it('should handle missing resources', (done) => {
@@ -2071,7 +2072,7 @@ describe('jupyter.services - kernel', () => {
                              'kernelspecs': { 'R': R_SPEC } });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, 'No valid kernelspecs found');
+      expectAjaxError(promise, done, 'No valid kernelspecs found');
     });
 
     it('should throw an error for an invalid response', (done) => {
@@ -2079,7 +2080,7 @@ describe('jupyter.services - kernel', () => {
         handler.respond(201, { });
       });
       let promise = getKernelSpecs();
-      expectFailure(promise, done, '201 Created');
+      expectAjaxError(promise, done, 'Invalid Status: 201');
     });
 
   });

--- a/test/src/testsession.ts
+++ b/test/src/testsession.ts
@@ -5,7 +5,7 @@
 import expect = require('expect.js');
 
 import {
-  uuid
+  uuid, IAjaxError
 } from '../../lib/utils';
 
 import {
@@ -65,7 +65,7 @@ function createSessionOptions(sessionModel?: ISession.IModel): ISession.IOptions
 }
 
 
-describe('jupyter.services - session', () => {
+describe('session', () => {
 
   describe('listRunningSessions()', () => {
 
@@ -118,7 +118,7 @@ describe('jupyter.services - session', () => {
         handler.respond(201, [createSessionModel()]);
       });
       let list = listRunningSessions();
-      expectFailure(list, done, 'Invalid Status: 201');
+      expectFailure(list, done);
     });
 
     it('should fail for error response status', (done) => {
@@ -243,7 +243,7 @@ describe('jupyter.services - session', () => {
       });
       let options = createSessionOptions(sessionModel);
       let sessionPromise = startNewSession(options);
-      expectFailure(sessionPromise, done, 'Invalid Status: 200');
+      expectFailure(sessionPromise, done);
     });
 
     it('should fail for error response status', (done) => {
@@ -270,7 +270,7 @@ describe('jupyter.services - session', () => {
       });
       let options = createSessionOptions(sessionModel);
       let sessionPromise = startNewSession(options);
-      let msg = `Session failed to start: No running kernel with id: ${sessionModel.kernel.id}`
+      let msg = `Session failed to start: No running kernel with id: ${sessionModel.kernel.id}`;
       expectFailure(sessionPromise, done, msg);
     });
 
@@ -691,7 +691,7 @@ describe('jupyter.services - session', () => {
           let promise = session.rename(newPath);
           tester.onRequest = () => {
             tester.respond(201, { });
-            expectFailure(promise, done, 'Invalid Status: 201');
+            expectFailure(promise, done);
           };
         });
       });
@@ -891,7 +891,7 @@ describe('jupyter.services - session', () => {
             tester.respond(200, { });
           };
           let promise = session.shutdown();
-          expectFailure(promise, done, 'Invalid Status: 200');
+          expectFailure(promise, done);
         });
       });
 
@@ -902,10 +902,10 @@ describe('jupyter.services - session', () => {
           tester.onRequest = () => {
             tester.respond(410, { });
           };
-          let promise = session.shutdown();
-          expectFailure(
-            promise, done, 'The kernel was deleted but the session was not'
-          );
+          session.shutdown().catch((err: IAjaxError) => {
+            let text ='The kernel was deleted but the session was not';
+            expect(err.throwError).to.contain(text);
+          }).then(done, done);
         });
       });
 

--- a/test/src/testutils.ts
+++ b/test/src/testutils.ts
@@ -210,10 +210,11 @@ describe('jupyter-js-utils', () => {
         called = true;
         request.respond(200, 'hello!');
       };
+
       ajaxRequest('hello', {}).then(response => {
         expect(called).to.be(true);
         expect(response.data).to.be('hello!');
-        expect(response.statusText).to.be('200 OK');
+        expect(response.xhr.statusText).to.be('200 OK');
       }).then(done, done);
     });
 
@@ -238,7 +239,8 @@ describe('jupyter-js-utils', () => {
         timeout: 5
       }).then(response => {
         expect(response.data).to.be('hello!');
-        expect(response.statusText).to.be('200 OK');
+        expect(response.xhr.statusText).to.be('200 OK');
+        expect(response.ajaxSettings.method).to.be('POST');
       }).then(done, done);
     });
 
@@ -247,8 +249,8 @@ describe('jupyter-js-utils', () => {
         request.respond(400, 'denied!');
       };
       ajaxRequest('hello', {}).catch(response => {
-        expect(response.statusText).to.be('400 Bad Request');
-        expect(response.error.message).to.be('400 Bad Request');
+        expect(response.xhr.statusText).to.be('400 Bad Request');
+        expect(response.throwError).to.be('400 Bad Request');
       }).then(done, done);
     });
 
@@ -257,8 +259,7 @@ describe('jupyter-js-utils', () => {
         request.error(new Error('Denied!'));
       };
       ajaxRequest('hello', {}).catch(response => {
-        expect(response.statusText).to.be('');
-        expect(response.error.message).to.be('Denied!');
+        expect(response.event.message).to.be('Denied!');
       }).then(done, done);
     });
 

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -5,7 +5,7 @@
 import encoding = require('text-encoding');
 
 import {
-  IAjaxSettings, PromiseDelegate, uuid
+  IAjaxSettings, PromiseDelegate, uuid, IAjaxError
 } from '../../lib/utils';
 
 import {
@@ -265,6 +265,21 @@ function expectFailure(promise: Promise<any>, done: () => void, message?: string
   }, (error: Error) => {
     if (message && error.message.indexOf(message) === -1) {
       throw Error(`Error "${message}" not in: "${error.message}"`);
+    }
+  }).then(done, done);
+}
+
+
+/**
+ * Expect an Ajax failure with a given throwError.
+ */
+export
+function expectAjaxError(promise: Promise<any>, done: () => void, throwError: string): Promise<any> {
+  return promise.then((msg: any) => {
+    throw Error('Expected failure did not occur');
+  }, (error: IAjaxError) => {
+    if (error.throwError !== throwError) {
+      throw Error(`Error "${throwError}" not equal to "${error.throwError}"`);
     }
   }).then(done, done);
 }

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -261,15 +261,12 @@ function createKernel(tester?: KernelTester): Promise<IKernel> {
 export
 function expectFailure(promise: Promise<any>, done: () => void, message?: string): Promise<any> {
   return promise.then((msg: any) => {
-    console.error('***should not reach this point');
-    throw Error('Should not reach this point');
-  }).catch((error) => {
+    throw Error('Expected failure did not occur');
+  }, (error: Error) => {
     if (message && error.message.indexOf(message) === -1) {
-      console.error('****', message, 'not in:', error.message);
-      return;
+      throw Error(`Error "${message}" not in: "${error.message}"`);
     }
-    done();
-  });
+  }).then(done, done);
 }
 
 


### PR DESCRIPTION
Fixes #208.

Matches the API of http://api.jquery.com/ajaxSuccess/ and http://api.jquery.com/ajaxError/
All ajax-related methods reject IAjaxError on error.

cc @minrk 