### PR TITLE
Take a less-stringent stance on JSON parsing of responses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -374,13 +374,10 @@ function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuc
         reject({ event, xhr, ajaxSettings, throwError: xhr.statusText });
       }
       let data = xhr.responseText;
-      if (ajaxSettings.dataType === 'json' && data) {
-        try {
-          data = JSON.parse(data);
-        } catch (err) {
-          let throwError = err.message;
-          reject({ event, xhr, ajaxSettings, throwError });
-        }
+      try {
+        data = JSON.parse(data);
+      } catch (err) {
+        // no-op
       }
       resolve({ xhr, ajaxSettings, data, event });
     };


### PR DESCRIPTION
We may have requested JSON but the server returns an HTML redirect, for example.

cc @minrk 