### PR TITLE
Do not print an error for comm msgs we don't care about

### DIFF
--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -871,7 +871,7 @@ class DefaultKernel implements IKernel {
     if (!promise) {
       let comm = this._comms.get(content.comm_id);
       if (!comm) {
-        console.error('Comm not found for comm id ' + content.comm_id);
+        // We do have a registered comm for this comm id, ignore.
         return;
       } else {
         let onMsg = comm.onMsg;


### PR DESCRIPTION
Comm messages are intended for a single frontend client that has established a comm link.  
If we receive a comm message that we do not have a comm handler for, ignore it.

cf #233 