### PR TITLE
More API Updates

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -59,7 +59,7 @@ namespace Contents {
     /**
      * The type of file.
      */
-    type?: FileType;
+    type?: ContentType;
 
     /**
      * Whether the requester has permission to edit the file.
@@ -102,7 +102,7 @@ namespace Contents {
    * A contents file type.
    */
   export
-  type FileType = 'notebook' | 'file' | 'directory';
+  type ContentType = 'notebook' | 'file' | 'directory';
 
 
   /**
@@ -119,7 +119,7 @@ namespace Contents {
     /**
      * The override file type for the request.
      */
-    type?: FileType;
+    type?: ContentType;
 
     /**
      * The override file format for the request.
@@ -155,7 +155,7 @@ namespace Contents {
     /**
      * The file type.
      */
-    type?: FileType;
+    type?: ContentType;
   }
 
   /**

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -71,10 +71,34 @@ interface IServiceManager extends IDisposable {
 
 
 /**
- * The namespace for `IServiceManager` statics.
+ * The namespace for `ServiceManager` statics.
  */
 export
-namespace IServiceManager {
+namespace ServiceManager {
+  /**
+   * Create a new service manager.
+   *
+   * @param options - The service manager creation options.
+   *
+   * @returns A promise that resolves with a service manager.
+   */
+  export
+  function create(options: IOptions = {}): Promise<IServiceManager> {
+    options.baseUrl = options.baseUrl || getBaseUrl();
+    options.ajaxSettings = options.ajaxSettings || {};
+    if (options.kernelspecs) {
+      return Promise.resolve(new DefaultServiceManager(options));
+    }
+    let kernelOptions: Kernel.IOptions = {
+      baseUrl: options.baseUrl,
+      ajaxSettings: options.ajaxSettings
+    };
+    return Kernel.getSpecs(kernelOptions).then(specs => {
+      options.kernelspecs = specs;
+      return new DefaultServiceManager(options);
+    });
+  }
+
   /**
    * The options used to create a service manager.
    */
@@ -97,40 +121,15 @@ namespace IServiceManager {
   }
 }
 
-/**
- * Create a new service manager.
- *
- * @param options - The service manager creation options.
- *
- * @returns A promise that resolves with a service manager.
- */
-export
-function createServiceManager(options: IServiceManager.IOptions = {}): Promise<IServiceManager> {
-  options.baseUrl = options.baseUrl || getBaseUrl();
-  options.ajaxSettings = options.ajaxSettings || {};
-  if (options.kernelspecs) {
-    return Promise.resolve(new ServiceManager(options));
-  }
-  let kernelOptions: Kernel.IOptions = {
-    baseUrl: options.baseUrl,
-    ajaxSettings: options.ajaxSettings
-  };
-  return Kernel.getSpecs(kernelOptions).then(specs => {
-    options.kernelspecs = specs;
-    return new ServiceManager(options);
-  });
-}
-
 
 /**
  * An implementation of a services manager.
  */
-export
-class ServiceManager implements IServiceManager {
+class DefaultServiceManager implements IServiceManager {
   /**
    * Construct a new services provider.
    */
-  constructor(options: IServiceManager.IOptions) {
+  constructor(options: ServiceManager.IOptions) {
     let subOptions: JSONObject = {
       baseUrl: options.baseUrl,
       ajaxSettings: options.ajaxSettings
@@ -147,7 +146,7 @@ class ServiceManager implements IServiceManager {
   /**
    * A signal emitted when the specs change on the service manager.
    */
-  specsChanged: ISignal<ServiceManager, Kernel.ISpecModels>;
+  specsChanged: ISignal<this, Kernel.ISpecModels>;
 
   /**
    * Test whether the terminal manager is disposed.
@@ -220,4 +219,4 @@ class ServiceManager implements IServiceManager {
 
 
 // Define the signals for the `ServiceManager` class.
-defineSignal(ServiceManager.prototype, 'specsChanged');
+defineSignal(DefaultServiceManager.prototype, 'specsChanged');

--- a/test/src/testmanager.ts
+++ b/test/src/testmanager.ts
@@ -13,7 +13,7 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  IServiceManager, createServiceManager
+  IServiceManager, ServiceManager
 } from '../../lib/manager';
 
 import {
@@ -35,13 +35,13 @@ import {
 
 describe('manager', () => {
 
-  describe('createServiceManager()', () => {
+  describe('ServiceManager.create()', () => {
 
     it('should accept no arguments', (done) => {
       let handler = new RequestHandler(() => {
         handler.respond(200, KERNELSPECS);
       });
-      createServiceManager().then(manager => {
+      ServiceManager.create().then(manager => {
         expect(manager.kernels).to.be.a(KernelManager);
         done();
       }).catch(done);
@@ -52,7 +52,7 @@ describe('manager', () => {
         baseUrl: 'foo',
         kernelspecs: KERNELSPECS
       };
-      createServiceManager(options).then(manager => {
+      ServiceManager.create(options).then(manager => {
         expect(manager.kernels).to.be.a(KernelManager);
         done();
       }).catch(done);
@@ -68,7 +68,7 @@ describe('manager', () => {
       let handler = new RequestHandler(() => {
         handler.respond(200, KERNELSPECS);
       });
-      createServiceManager().then(value => {
+      ServiceManager.create().then(value => {
         manager = value;
         done();
       });


### PR DESCRIPTION
Update the ServiceManager API to the new style.
Rename `Content.FileType` -> `Content.ContentType` to avoid ambiguity with the `FileType` object in JupyterLab.