### PR TITLE
Buffers are an optional property in the spec

### DIFF
--- a/src/kernel/validate.ts
+++ b/src/kernel/validate.ts
@@ -81,7 +81,6 @@ function validateMessage(msg: KernelMessage.IMessage) : void {
   validateProperty(msg, 'metadata', 'object');
   validateProperty(msg, 'content', 'object');
   validateProperty(msg, 'channel', 'string');
-  validateProperty(msg, 'buffers', 'array');
   validateHeader(msg.header);
   if (Object.keys(msg.parent_header).length > 0) {
     validateHeader(msg.parent_header as KernelMessage.IHeader);


### PR DESCRIPTION
http://jupyter-client.readthedocs.io/en/latest/messaging.html#general-message-format

We were getting invalid messages for those that were missing this optional field due to improper validation.