### PR TITLE
Types used in the codebase need to be installed as normal dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
+    "@types/minimist": "^1.1.29",
+    "@types/node": "^6.0.42",
     "minimist": "^1.2.0",
     "path-posix": "^1.0.0",
     "phosphor": "^0.5.0",
@@ -13,9 +15,7 @@
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",
-    "@types/minimist": "^1.1.29",
     "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.42",
     "@types/text-encoding": "0.0.30",
     "@types/ws": "0.0.33",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Otherwise the types are not installed for packages that depend on this package.