### PR TITLE
Limit the kernel interface in a session

### DIFF
--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -36,7 +36,7 @@ import {
 export
 namespace Kernel {
   /**
-   * Interface of a Kernel object.
+   * Interface of a Kernel connection that is managed by a session.
    *
    * #### Notes
    * The Kernel object is tied to the lifetime of the Kernel id, which is
@@ -46,27 +46,7 @@ namespace Kernel {
    * process on the server, but preserves the Kernel id.
    */
   export
-  interface IKernel extends IDisposable {
-    /**
-     * A signal emitted when the kernel is shut down.
-     */
-    terminated: ISignal<this, void>;
-
-    /**
-     * A signal emitted when the kernel status changes.
-     */
-    statusChanged: ISignal<this, Kernel.Status>;
-
-    /**
-     * A signal emitted for iopub kernel messages.
-     */
-    iopubMessage: ISignal<this, KernelMessage.IIOPubMessage>;
-
-    /**
-     * A signal emitted for unhandled kernel message.
-     */
-    unhandledMessage: ISignal<this, KernelMessage.IMessage>;
-
+  interface IKernelConnection extends IDisposable {
     /**
      * The id of the server-side kernel.
      */
@@ -91,16 +71,6 @@ namespace Kernel {
      * The client unique id.
      */
     readonly clientId: string;
-
-    /**
-     * The base url of the kernel.
-     */
-    readonly baseUrl: string;
-
-    /**
-     * The Ajax settings used for server requests.
-     */
-    ajaxSettings: IAjaxSettings;
 
     /**
      * The current status of the kernel.
@@ -161,40 +131,6 @@ namespace Kernel {
     sendShellMessage(msg: KernelMessage.IShellMessage, expectReply?: boolean, disposeOnDone?: boolean): Kernel.IFuture;
 
     /**
-     * Interrupt a kernel.
-     *
-     * @returns A promise that resolves when the kernel has interrupted.
-     *
-     * #### Notes
-     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
-     *
-     * The promise is fulfilled on a valid response and rejected otherwise.
-     *
-     * It is assumed that the API call does not mutate the kernel id or name.
-     *
-     * The promise will be rejected if the kernel status is `'dead'` or if the
-     * request fails or the response is invalid.
-     */
-    interrupt(): Promise<void>;
-
-    /**
-     * Restart a kernel.
-     *
-     * @returns A promise that resolves when the kernel has restarted.
-     *
-     * #### Notes
-     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels) and validates the response model.
-     *
-     * Any existing Future or Comm objects are cleared.
-     *
-     * It is assumed that the API call does not mutate the kernel id or name.
-     *
-     * The promise will be rejected if the kernel status is `'dead'` or if the
-     * request fails or the response is invalid.
-     */
-    restart(): Promise<void>;
-
-    /**
      * Reconnect to a disconnected kernel.
      *
      * @returns A promise that resolves when the kernel has reconnected.
@@ -205,25 +141,6 @@ namespace Kernel {
      * lost.
      */
     reconnect(): Promise<void>;
-
-    /**
-     * Shutdown a kernel.
-     *
-     * @returns A promise that resolves when the kernel has shut down.
-     *
-     * #### Notes
-     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
-     *
-     * On a valid response, closes the websocket and disposes of the kernel
-     * object, and fulfills the promise.
-     *
-     * The promise will be rejected if the kernel status is `'dead'` or if the
-     * request fails or the response is invalid.
-     *
-     * If the server call is successful, the [[terminated]] signal will be
-     * emitted.
-     */
-    shutdown(): Promise<void>;
 
     /**
      * Send a `kernel_info_request` message.
@@ -397,6 +314,95 @@ namespace Kernel {
   }
 
   /**
+   * The full interface of a kernel.
+   */
+  export
+  interface IKernel extends IKernelConnection {
+    /**
+     * A signal emitted when the kernel is shut down.
+     */
+    terminated: ISignal<this, void>;
+
+    /**
+     * A signal emitted when the kernel status changes.
+     */
+    statusChanged: ISignal<this, Kernel.Status>;
+
+    /**
+     * A signal emitted for iopub kernel messages.
+     */
+    iopubMessage: ISignal<this, KernelMessage.IIOPubMessage>;
+
+    /**
+     * A signal emitted for unhandled kernel message.
+     */
+    unhandledMessage: ISignal<this, KernelMessage.IMessage>;
+
+    /**
+     * The base url of the kernel.
+     */
+    readonly baseUrl: string;
+
+    /**
+     * The Ajax settings used for server requests.
+     */
+    ajaxSettings: IAjaxSettings;
+
+    /**
+     * Interrupt a kernel.
+     *
+     * @returns A promise that resolves when the kernel has interrupted.
+     *
+     * #### Notes
+     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
+     *
+     * The promise is fulfilled on a valid response and rejected otherwise.
+     *
+     * It is assumed that the API call does not mutate the kernel id or name.
+     *
+     * The promise will be rejected if the kernel status is `'dead'` or if the
+     * request fails or the response is invalid.
+     */
+    interrupt(): Promise<void>;
+
+    /**
+     * Restart a kernel.
+     *
+     * @returns A promise that resolves when the kernel has restarted.
+     *
+     * #### Notes
+     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels) and validates the response model.
+     *
+     * Any existing Future or Comm objects are cleared.
+     *
+     * It is assumed that the API call does not mutate the kernel id or name.
+     *
+     * The promise will be rejected if the kernel status is `'dead'` or if the
+     * request fails or the response is invalid.
+     */
+    restart(): Promise<void>;
+
+    /**
+     * Shutdown a kernel.
+     *
+     * @returns A promise that resolves when the kernel has shut down.
+     *
+     * #### Notes
+     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
+     *
+     * On a valid response, closes the websocket and disposes of the kernel
+     * object, and fulfills the promise.
+     *
+     * The promise will be rejected if the kernel status is `'dead'` or if the
+     * request fails or the response is invalid.
+     *
+     * If the server call is successful, the [[terminated]] signal will be
+     * emitted.
+     */
+    shutdown(): Promise<void>;
+  }
+
+  /**
    * Find a kernel by id.
    *
    * #### Notes
@@ -483,6 +489,8 @@ namespace Kernel {
     return DefaultKernel.shutdown(id, options);
   }
 
+  /**
+   * The interface of a kernel
   /**
    * The options object used to initialize a kernel.
    */

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -143,6 +143,40 @@ namespace Kernel {
     reconnect(): Promise<void>;
 
     /**
+     * Interrupt a kernel.
+     *
+     * @returns A promise that resolves when the kernel has interrupted.
+     *
+     * #### Notes
+     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
+     *
+     * The promise is fulfilled on a valid response and rejected otherwise.
+     *
+     * It is assumed that the API call does not mutate the kernel id or name.
+     *
+     * The promise will be rejected if the kernel status is `'dead'` or if the
+     * request fails or the response is invalid.
+     */
+    interrupt(): Promise<void>;
+
+    /**
+     * Restart a kernel.
+     *
+     * @returns A promise that resolves when the kernel has restarted.
+     *
+     * #### Notes
+     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels) and validates the response model.
+     *
+     * Any existing Future or Comm objects are cleared.
+     *
+     * It is assumed that the API call does not mutate the kernel id or name.
+     *
+     * The promise will be rejected if the kernel status is `'dead'` or if the
+     * request fails or the response is invalid.
+     */
+    restart(): Promise<void>;
+
+    /**
      * Send a `kernel_info_request` message.
      *
      * @param content - The content of the request.
@@ -347,40 +381,6 @@ namespace Kernel {
      * The Ajax settings used for server requests.
      */
     ajaxSettings: IAjaxSettings;
-
-    /**
-     * Interrupt a kernel.
-     *
-     * @returns A promise that resolves when the kernel has interrupted.
-     *
-     * #### Notes
-     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
-     *
-     * The promise is fulfilled on a valid response and rejected otherwise.
-     *
-     * It is assumed that the API call does not mutate the kernel id or name.
-     *
-     * The promise will be rejected if the kernel status is `'dead'` or if the
-     * request fails or the response is invalid.
-     */
-    interrupt(): Promise<void>;
-
-    /**
-     * Restart a kernel.
-     *
-     * @returns A promise that resolves when the kernel has restarted.
-     *
-     * #### Notes
-     * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels) and validates the response model.
-     *
-     * Any existing Future or Comm objects are cleared.
-     *
-     * It is assumed that the API call does not mutate the kernel id or name.
-     *
-     * The promise will be rejected if the kernel status is `'dead'` or if the
-     * request fails or the response is invalid.
-     */
-    restart(): Promise<void>;
 
     /**
      * Shutdown a kernel.

--- a/src/session/default.ts
+++ b/src/session/default.ts
@@ -67,7 +67,7 @@ class DefaultSession implements Session.ISession {
   /**
    * A signal emitted when the kernel changes.
    */
-  get kernelChanged(): ISignal<this, Kernel.IKernel> {
+  get kernelChanged(): ISignal<this, Kernel.IKernelConnection> {
     return this._kernelChanged;
   }
 
@@ -114,7 +114,7 @@ class DefaultSession implements Session.ISession {
    * Use the [statusChanged] and [unhandledMessage] signals on the session
    * instead of the ones on the kernel.
    */
-  get kernel() : Kernel.IKernel {
+  get kernel() : Kernel.IKernelConnection {
     return this._kernel;
   }
 
@@ -259,7 +259,7 @@ class DefaultSession implements Session.ISession {
    * This shuts down the existing kernel and creates a new kernel,
    * keeping the existing session ID and session path.
    */
-  changeKernel(options: Kernel.IModel): Promise<Kernel.IKernel> {
+  changeKernel(options: Kernel.IModel): Promise<Kernel.IKernelConnection> {
     if (this.isDisposed) {
       return Promise.reject(new Error('Session is disposed'));
     }
@@ -369,7 +369,7 @@ class DefaultSession implements Session.ISession {
   private _baseUrl = '';
   private _options: Session.IOptions = null;
   private _updating = false;
-  private _kernelChanged = new Signal<this, Kernel.IKernel>(this);
+  private _kernelChanged = new Signal<this, Kernel.IKernelConnection>(this);
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -48,7 +48,7 @@ namespace Session {
     /**
      * A signal emitted when the kernel changes.
      */
-    kernelChanged: ISignal<ISession, Kernel.IKernel>;
+    kernelChanged: ISignal<ISession, Kernel.IKernelConnection>;
 
     /**
      * A signal emitted when the session status changes.
@@ -95,10 +95,8 @@ namespace Session {
      *
      * #### Notes
      * This is a read-only property, and can be altered by [changeKernel].
-     * Use the [statusChanged] and [unhandledMessage] signals on the session
-     * instead of the ones on the kernel.
      */
-    readonly kernel: Kernel.IKernel;
+    readonly kernel: Kernel.IKernelConnection;
 
     /**
      * The current status of the session.


### PR DESCRIPTION
Do not expose the signals or the shutdown method, to force them to be used on the session itself.

cf https://github.com/jupyterlab/jupyterlab/issues/1856